### PR TITLE
Stop using spans for word wrap

### DIFF
--- a/dwitter/feed/templates/feed/feed.html
+++ b/dwitter/feed/templates/feed/feed.html
@@ -178,9 +178,7 @@
           <a class=arktis-link id=arktis-link-{{dweet.id}} href="{% url 'fullscreen_dweet' subdomain='dweet' dweet_id=dweet.id %}" >fullscreen</a>
         </div>
         <div class=dweet-author><a href="{% url 'user_feed' url_username=dweet.author.username %}">{{ dweet.author.username }}</a></div>
-        <div class=dweet-code>
-          {% for char in dweet.code|make_list %}<span class=code-letter><code>{{ char }}</code></span>{% endfor %}
-        </div>
+        <div class=dweet-code><code>{{ dweet.code }}</code></div>
       </div>
       {% endfor %}
 

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -49,12 +49,10 @@
         padding-top:5em;
         margin: 0 auto;
       }
-      .code-letter {
-        float:left;
-      }
 
-      .dweet-code {
-        overflow:hidden;
+      .dweet .code {
+        white-space: pre;
+        word-wrap: break;
       }
 
       .dweet-feed {


### PR DESCRIPTION
Using css instead results in less html markup, and more readable source
code.