### PR TITLE
Fix demos that raise exceptions in u(t)

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -91,16 +91,21 @@
       };
     var x = c.getContext("2d");
     var time = 0;
+    var firstFrameDrawn = false;
     function u(t) {
        {{ code | safe }}
-      };
+      }
     function loop() {
-      if(playing){
+      if (playing){
         requestAnimationFrame(loop);
       }
+      if (firstFrameDrawn) {
+        time += 1/60;
+      } else {
+        firstFrameDrawn = true;
+      }
       u(time);
-      time += 1/60;
-      };
+    }
     loop();
 
     function reset(){
@@ -116,6 +121,7 @@
       };
       x = c.getContext("2d");
       time = 0;
+      firstFrameDrawn = false;
     }
     </script>
 


### PR DESCRIPTION
In a few of my demos u(t) raises an exception, so `time += 1/60;` wouldn't be called and the demo stopped. One quickfix is to call time += 1/60 _before_ calling u(t).

However, some demos rely on t being 0 the first frame. To make sure this is still the case I won't increase the time before drawing the first frame.