### PR TITLE
Add word-break: break-all to code-inputs

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -111,6 +111,7 @@ code {
   width:100%;
   font-family: Pragmata, Menlo, 'DejaVu LGC Sans Mono', 'DejaVu Sans Mono', Consolas, 'Everson Mono', 'Lucida Console', 'Andale Mono', 'Nimbus Mono L', 'Liberation Mono', FreeMono, 'Osaka Monospaced', Courier, 'New Courier', monospace;
   white-space: pre-line;
+  word-break: break-all;
 }
 .dweet-button {
   float: right;


### PR DESCRIPTION
This will ensure that line breaking only occurs when a line of the
container is full, and stop lines from breaking at hyphens, spaces and
other word-splitting characters.