### PR TITLE
Don't start demo if it is paused

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -106,7 +106,9 @@
       }
       u(time);
     }
-    loop();
+    if (playing) {
+      loop();
+    }
 
     function reset(){
       c = document.querySelector("#c");


### PR DESCRIPTION
... so that demos that are out of view get the first loop call when they are actually scrolled into view