### PR TITLE
Restyle comments view

### DIFF
--- a/dwitter/feed/templates/feed/feed.html
+++ b/dwitter/feed/templates/feed/feed.html
@@ -132,36 +132,39 @@
           {% endif %}
           <div class=dweet-changed>
         {% if request.user.is_authenticated %}
-            <input  
+            <input
             class=dweet-button
-            type="submit" 
+            type="submit"
             value="Post as new dweet!" />
             {% else %}
-            <p> Please <a href="{% url 'auth_login'  %}" >log in</a> to post as a new dweet (copy-paste code somewhere safe to save it meanwhile) </p>
+            <p>Please <a href="{% url 'auth_login' %}">log in</a> to post as a new dweet (copy-paste code somewhere safe to save it meanwhile).</p>
             {% endif %}
           </div>
         </form>
       </div>
       <div class=comment-section>
-        <div class=comments>
+        <ul class=comments>
           {% if dweet.comments.count > 3 %}
-          <div class=comment>
-            <a href="javascript:;" class="load-comments-link" data-dweet_id="{{ dweet.id }}" 
-              data-offset=3> Load older comments... </a>
-          </div>
+          <li class=comment>
+            <a href="javascript:;" class="load-comments-link" data-dweet_id="{{ dweet.id }}"
+              data-offset=3>Load older comments...</a>
+          </li>
           {% endif %}
           {% for comment in dweet.comments.all|slice:"3" reversed %}
-          <div class=comment><p><b>{{ comment.author.username }}:</b> {{ comment.text }}</p></div>
+          <li class=comment>
+            <a class=comment-name href="{% url 'user_feed' url_username=dweet.author.username %}">{{ comment.author.username }}:</a>
+            <span class="comment-message">{{ comment.text }}</span>
+          </li>
           {% endfor %}
-        </div>
-        <div class=new-comment>
+        </ul>
+        <form class=new-comment data-csrf="{{ csrf_token }}" data-dweet_id="{{dweet.id}}">
           {% if request.user.is_authenticated %}
           <input type=text class=comment-input />
-          <input type=button value="Post comment" data-dweet_id="{{dweet.id}}" data-csrf="{{ csrf_token }}" class=comment-submit />
-          {%else%}
-          <p> Please <a href="{% url 'auth_login'  %}" >log in</a> to comment. </p>
+          <input type=submit value="Post comment" class=comment-submit />
+          {% else %}
+          <p>Please <a href="{% url 'auth_login' %}">log in</a> to comment.</p>
           {%endif%}
-        </div>
+        </form>
       </div>
     </div>
       {% endfor %}

--- a/dwitter/static/js/ajax-handling.js
+++ b/dwitter/static/js/ajax-handling.js
@@ -26,8 +26,12 @@ var processLike = function()  {
 };
 
 var getCommentHTML = function(comment) {
-       return '<div class=comment><p><span class=comment-name>'+comment.author+':</span> '+comment.text+'</p></div>';
-}
+  return '<li class=comment><a class=comment-name href="/u/' + comment.author + '">' +
+    comment.author + ':</a> ' +
+    '<span class="comment-message">' + comment.text +
+    '</span></li>';
+};
+
 var loadComments = function() {
   var step = 1000;
   var current_offset = $(this).data('offset') ;
@@ -64,12 +68,13 @@ var loadComments = function() {
    $.ajax(config);
 }
 
-var postComment = function() {
-  var $post_comment_button = $(this);
-  var dweet_id = $post_comment_button.data('dweet_id');
-  var csrf = $post_comment_button.data('csrf');
-  var $comment_text = $post_comment_button.siblings('.comment-input');
-  var $comment_section = $post_comment_button.closest('.comment-section').children('.comments');
+var postComment = function(e) {
+  e.preventDefault();
+  var $postForm = $(this);
+  var dweet_id = $postForm.data('dweet_id');
+  var csrf = $postForm.data('csrf');
+  var $comment_text = $postForm.find('.comment-input');
+  var $comment_section = $postForm.closest('.comment-section').children('.comments');
 
   var postCommentResponse = function(serverResponse_json, textStatus_ignored,
       jqXHR_ignored)  {
@@ -98,5 +103,5 @@ var postComment = function() {
 $(document).ready(function()  {
   $('body').on('click','.like-button', processLike);
   $('body').on('click','.load-comments-link', loadComments);
-  $('body').on('click','.comment-submit', postComment);
+  $('body').on('submit','.new-comment', postComment);
 });

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -100,19 +100,43 @@ code {
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 .comment-section{
-  background: #f6f6f6;
+  background: #fbfbfb;
   padding: 20px;
-  border: 1px solid #ddd;
-  border-top: 0px;
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
   box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+}
+
+.comments {
+  list-style-type: none;
+  padding: none;
 }
 
 .comment-name{
   font-weight:bold;
 }
 
-.comment-submit{
-  padding:15px
+.new-comment {
+  margin-top: 10px;
+  display: flex;
+  display: -webkit-flex;
+}
+
+.comment-input{
+  flex: 1;
+  text-align:left;
+  width:80%;
+}
+
+input.comment-submit {
+  padding: 3px;
+  margin: 0;
+  margin-left: 5px;
+  color: currentcolor;
+  cursor: pointer;
+}
+input.comment-submit:active {
+  transform: translateY(1px);
 }
 
 .submit-box {
@@ -135,15 +159,6 @@ code {
 }
 .dweet-button {
   float: right;
-}
-
-.comment-input{
-  text-align:left;
-  resize:none;
-  width:80%;
-  font-family: Pragmata, Menlo, 'DejaVu LGC Sans Mono', 'DejaVu Sans Mono', Consolas, 'Everson Mono', 'Lucida Console', 'Andale Mono', 'Nimbus Mono L', 'Liberation Mono', FreeMono, 'Osaka Monospaced', Courier, 'New Courier', monospace;
-  white-space: pre-line;
-  word-break: break-all;
 }
 
 .canvas-iframe-container-wrapper {


### PR DESCRIPTION
The fixes are kind of intertangled, so I didn't bother splitting them
into separate commits.

- The HTML is rewritten so comments are contained in an unordered list.
- The background color of the comments view is made lighter, to
  differentiate it from the background.
- The comment input field no longer uses a monospaced font.
- The width of the new-comment form is stretched to fit the parent.
- The height of the text input and the submit button is made equal.
- You can now press enter in the comment input to submit the comment.