### PR TITLE
Fix comment author url

### DIFF
--- a/dwitter/feed/templates/feed/feed.html
+++ b/dwitter/feed/templates/feed/feed.html
@@ -152,7 +152,7 @@
           {% endif %}
           {% for comment in dweet.comments.all|slice:"3" reversed %}
           <li class=comment>
-            <a class=comment-name href="{% url 'user_feed' url_username=dweet.author.username %}">{{ comment.author.username }}:</a>
+            <a class=comment-name href="{% url 'user_feed' url_username=comment.author.username %}">{{ comment.author.username }}:</a>
             <span class="comment-message">{{ comment.text }}</span>
           </li>
           {% endfor %}


### PR DESCRIPTION
The link previously sent you to the author of the dweet the comment was
posted on, not the profile of the comment author.

This fixes #36