### PR TITLE
Use Fullscreen API for fullscreen button

### DIFF
--- a/dwitter/static/js/feed.js
+++ b/dwitter/static/js/feed.js
@@ -7,4 +7,19 @@ var onDweetChanged = function() {
 
 $(document).ready(function()  {
   $('body').on('input','.code-input', onDweetChanged);
+
+
+  function requestFullscreen(el) {
+    (el.mozRequestFullScreen ||
+     el.webkitRequestFullscreen ||
+     el.requestFullscreen).call(el);
+  }
+  $('.dweet').each(function(i, el) {
+    var link = $(el).find('.arktis-link');
+    var iframe = $(el).find('iframe.dweetiframe');
+    link.on('click', function(e) {
+      e.preventDefault();
+      requestFullscreen(iframe[0]);
+    });
+  });
 });

--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -30,12 +30,12 @@ window.onload = function() {
         },
         exit: function(dir) {
           var fullscreenElement = (document.fullscreenElement ||
-                                   document.webkitFullscreenElement ||
-                                   document.mozFullScreenElement);
+              document.webkitFullscreenElement ||
+              document.mozFullScreenElement);
           if(fullscreenElement != iframe) {
-                pause(iframe)
+            pause(iframe)
           }
-              },
+        },
     });
 
   }

--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -29,7 +29,12 @@ window.onload = function() {
           play(iframe)
         },
         exit: function(dir) {
+          var fullscreenElement = (document.fullscreenElement ||
+                                   document.webkitFullscreenElement ||
+                                   document.mozFullScreenElement);
+          if(fullscreenElement != iframe) {
                 pause(iframe)
+          }
               },
     });
 


### PR DESCRIPTION
Non-js clients will gracefully fall back to regular old linking. A
special-case is needed in the scrolling play/pause logic, since
Waypoints.inview thinks that fullscreened elements are not inview.

This fixes #38.