### PR TITLE
Honor playing status for first frame of dweet

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -109,7 +109,9 @@
 
       u(time);
     }
-    loop();
+    if(autoplay) {
+        loop();
+    }
 
     function reset(){
       c = document.querySelector("#c");


### PR DESCRIPTION
Previously, dweets would always render their first frame regardless of
if they are playing or not. This might be nice as a way to generate a
first preview of an effect, however it makes lists of dweets load slowly
since all the dweets in the list must render their first frames all at
once. This commit changes this behavior to honor the playing status.
That is, the first frame no longer behaves differently from other
frames.

This change was prompted by slow frontpage loading times on dwitter.net
caused by multiple heavy demos rendering their first frames all at once.