### PR TITLE
Implement reddit hot algorithm (and add timestamps to dweets)

### DIFF
--- a/dwitter/feed/urls.py
+++ b/dwitter/feed/urls.py
@@ -3,7 +3,7 @@ from . import views
 
 urlpatterns = [
     url(r'^$',
-        views.feed, {'page_nr': 1, 'sort': 'new'}, name='root'),
+        views.feed, {'page_nr': 1, 'sort': 'hot'}, name='root'),
 
     url(r'^page/(?P<page_nr>\d+)$',
         views.feed, {'sort': 'new'}, name='feed_page'),

--- a/dwitter/migrations/0010_dweet_hotscore.py
+++ b/dwitter/migrations/0010_dweet_hotscore.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dwitter', '0009_auto_20160816_1952'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dweet',
+            name='hotscore',
+            field=models.IntegerField(default=1),
+        ),
+    ]

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -10,6 +10,7 @@ class Dweet(models.Model):
 
     author = models.ForeignKey(User, on_delete=models.CASCADE)
     likes = models.ManyToManyField(User, related_name="liked")
+    hotscore = models.IntegerField(default=1)
 
     class Meta:
         ordering = ('-posted',)

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -280,6 +280,11 @@ iframe {
   display:none;
 }
 
+.dweet-timestamp{
+  float:right;
+  clear:both;
+}
+
 .dweet-actions {
   margin-top:10px;
   margin-bottom:20px;

--- a/dwitter/templates/feed/feed.html
+++ b/dwitter/templates/feed/feed.html
@@ -23,6 +23,7 @@
 {% block top-nav %}
 <ul class=top-sort-list>
   {%if feed_type == "all" %}
+  <li><a class="hot" href="{% url 'hot_feed' %}">hot</a></li>
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
   <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
   {%elif feed_type == "user" %}

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -42,6 +42,7 @@
         {% endif %}
       </div>
     </form>
+    <p class=dweet-timestamp> {{ dweet.posted }} </p>
     {% if request.user.is_authenticated %}
     {% if request.user == dweet.author or request.user.is_staff %}
     <form action="{% url 'dweet_delete' dweet_id=dweet.id %}" method="post"


### PR DESCRIPTION
fixes #62 

Implements reddits hot algorithm as of https://medium.com/hacking-and-gonzo/how-reddit-ranking-algorithms-work-ef111e33d0d9#.n30qlo7sg .

Numbers changed a bit so that it will take 24 * log_2(number of "awesome") hours before a post is being ranked under a post with 0 "awesome". Essentially the post gets 24*log_2(awesome) extra hours added to its timestamp and then you sort by this modified timestamp.

I'm very open to feedback on these numbers. They're set to work a bit slower than reddit (which is 12 * log_10(upvotes - downvotes) ), because we have both fewer votes and fewer posts.