### PR TITLE
Fix bug when posting empty comment using the required tag

### DIFF
--- a/dwitter/static/js/ajax-handling.js
+++ b/dwitter/static/js/ajax-handling.js
@@ -76,11 +76,16 @@ var postComment = function(e) {
   var $comment_text = $postForm.find('.comment-input');
   var $comment_section = $postForm.closest('.comment-section').children('.comments');
 
-  var postCommentResponse = function(serverResponse_json, textStatus_ignored,
+  var postCommentSuccess = function(serverResponse_json, textStatus_ignored,
       jqXHR_ignored)  {
 
     $comment_text[0].value = '';
     $comment_section[0].innerHTML =  $comment_section[0].innerHTML + getCommentHTML(serverResponse_json);
+  }
+
+  var postCommentError = function(serverResponse_json, textStatus_ignored,
+      jqXHR_ignored)  {
+    //Do nothing at the moment. TODO: Clearer error message displayed to the user?
   }
 
   var comment = {
@@ -92,8 +97,8 @@ var postComment = function(e) {
   var config = {
     url: '/api/comments/',
     method: 'POST',
-    success: postCommentResponse,
-    error: postCommentResponse,
+    success: postCommentSuccess,
+    error: postCommentError,
     data: comment,
   };
   $.ajax(config);

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -84,7 +84,7 @@
     </ul>
     <form class=new-comment data-csrf="{{ csrf_token }}" data-dweet_id="{{dweet.id}}">
       {% if request.user.is_authenticated %}
-      <input type=text class=comment-input />
+      <input type=text class=comment-input required />
       <input type=submit value="Post comment" class=comment-submit />
       {% else %}
       <p>Please <a href="{% url 'auth_login' %}">log in</a> (or <a href="{% url 'register'  %}" >register</a>) to comment.</p>


### PR DESCRIPTION
When posting an empty comment it got displayed as "invalid" in
the front end, but not added to the database. You should now get
an error when attempting to comment with an empty comment.

Fixes #86 