### PR TITLE
Feed loading indicator

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -83,6 +83,7 @@ def feed(request, page_nr, sort):
                'header_title': 'Dwitter',
                'feed_type': 'all',
                'page_nr': page,
+               'on_last_page': last == dweet_count,
                'next_url': next_url,
                'prev_url': prev_url,
                'sort': sort,

--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -2,9 +2,11 @@ window.onload = function() {
 
   var infinite = new Waypoint.Infinite({
     element: $('.dweet-feed')[0],
-      items: '.dweet-wrapper',
+      items: '.dweet-wrapper, .loading, .end-of-feed',
       more: '.next-page',
       onAfterPageLoad: function(items) {
+        $('.loading:not(:last-of-type)').hide();
+
         var dwiframes = [];
 
         function requestFullscreen(el) {

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -106,13 +106,17 @@ ul.messages {
   padding: 15px;
 }
 
-.dweet, .card {
+.dweet, .card, .loading, .end-of-feed {
   margin-top: 15px;
   padding: 15px;
   background:white;
   word-wrap: break-word;
   border:1px solid #ddd;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+.loading, .end-of-feed {
+  text-align: center;
 }
 
 .comment-section{

--- a/dwitter/templates/feed/feed.html
+++ b/dwitter/templates/feed/feed.html
@@ -16,7 +16,7 @@
 {% block body_class %}{{sort}}{% endblock %}
 
 
-{% block header_title %} 
+{% block header_title %}
 {{ header_title }}
 {% endblock %}
 
@@ -55,7 +55,13 @@
     {% include 'snippets/dweet_card.html' %}
   {% endfor %}
 
-  <a class=next-page href="{{ next_url }}">Next page</a>
+  <div class="loading">Loading...</div>
+
+  {% if on_last_page %}
+    <div class="end-of-feed">Congratulations! You've reached the end.</div>
+  {% else %}
+    <a class=next-page href="{{ next_url }}">Next page</a>
+  {% endif %}
 
 </div>
 


### PR DESCRIPTION
This PR is in response to https://github.com/lionleaf/dwitter/issues/12. It adds a loading indicator to the bottom of feeds when loading new posts. Also, when a user reaches the end of a feed, a message is displayed.

Demo:

![dwitter-infinite-scroll-loading](https://cloud.githubusercontent.com/assets/8731922/23198554/63eecfc0-f896-11e6-842d-f99f3bfc2a84.gif)
