### PR TITLE
Revise example dweet

### DIFF
--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -23,7 +23,9 @@
         class=code-input
         rows=4
         id=editor
-        >c.width=1920;for(i=0;i&lt;9;i++){x.fillRect(400+i*100+S(t)*300,400,50,200)}</textarea>
+        >c.width=1920; /* clear the canvas */
+for(i=0;i<9;i++)
+x.fillRect(400+i*100+S(t)*300, 400, 50, 200) /* draw 50x200 rects */</textarea>
       <div class=character-count>72/140</div>
     </div>
     <code>

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -26,7 +26,7 @@
         >c.width=1920; /* clear the canvas */
 for(i=0;i<9;i++)
 x.fillRect(400+i*100+S(t)*300, 400, 50, 200) /* draw 50x200 rects */</textarea>
-      <div class=character-count>72/140</div>
+      <div class=character-count>122/140</div>
     </div>
     <code>
       }


### PR DESCRIPTION
Might as well make the example code more readable, for people who aren't familiar with Canvas. It's not obvious that setting the width clears the canvas.

```
c.width=1920; /* clear the canvas */
for(i=0;i<9;i++)
x.fillRect(400+i*100+S(t)*300, 400, 50, 200) /* draw 50x200 rects */
```
