### PR TITLE
Redirect to localhost:8000 after login when running locally

### DIFF
--- a/dwitter/settings/local.py.example
+++ b/dwitter/settings/local.py.example
@@ -15,3 +15,6 @@ DATABASES = {
 # CHANGE THIS! THIS IS PUBLIC AS IT'S IN SOURCE CONTROL
 SECRET_KEY = '=^e_t38stu=a=3xuys_r1an%38xwmq347u%q0l3cy!wnybzuj)'
 
+BASE_URL = 'http://localhost:8000'
+LOGIN_REDIRECT_URL = BASE_URL
+LOGIN_URL = BASE_URL + '/accounts/login/'


### PR DESCRIPTION
This fixes a bug that only occurred when running Dwitter locally. After logging in locally, you would be redirected to dwitter.com instead of localhost:8000.

Demo:

![dwitter-login-local](https://cloud.githubusercontent.com/assets/8731922/23336751/d8c586b4-fba6-11e6-8763-625d23876608.gif)
