### PR TITLE
only allow POST to like endpoint; add CSRF token

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -154,6 +154,7 @@ def dweet_delete(request, dweet_id):
 
 
 @ajax_login_required
+@require_POST
 def like(request, dweet_id):
     dweet = get_object_or_404(Dweet, id=dweet_id)
 

--- a/dwitter/static/js/ajax-handling.js
+++ b/dwitter/static/js/ajax-handling.js
@@ -1,4 +1,17 @@
-
+function getCookie(name) {
+  if (document.cookie && document.cookie !== '') {
+    var cookies = document.cookie.split(';').map(function(cookie) {
+      return cookie.trim();
+    });
+    var cookie = cookies.find(function(cookie) {
+      return cookie.substring(0, name.length + 1) === (name + '=');
+    });
+    if (cookie) {
+      return decodeURIComponent(cookie.substring(name.length + 1));
+    }
+  }
+  return null;
+}
 
 var processLike = function()  {
    var $like_button = $(this);
@@ -20,6 +33,10 @@ var processLike = function()  {
    var config = {
      url: '/d/' + dweet_id + '/like',
      dataType: 'json',
+      method: 'POST',
+      headers: {
+        'X-CSRFToken': getCookie('csrftoken'),
+      },
       success: processServerResponse,
    };
    $.ajax(config);


### PR DESCRIPTION
This PR changes endpoints for liking dweets so that only POST requests are accepted. This prevents dweets like https://www.dwitter.net/d/1058 from causing users to inadvertently like/unlike dweets.

I've also added a CSRF token to dweet-liking requests.