### PR TITLE
Add link to 'my profile' in user dropdown.

### DIFF
--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -36,6 +36,7 @@
         <a class=name href="{% url 'user_feed' url_username=request.user.username %}">{{ request.user.username }}</a>
         <div class=avatar style="background-image: url({{ request.user.email | to_gravatar_url }})"></div>
         <ul class=collapsible>
+          <li><a href="{% url 'user_feed' url_username=request.user.username %}"> My profile </a></li>
           <li><a href="{% url 'password_change' %}"> Change password </a></li>
           <li><a href="{% url 'auth_logout' %}"> Log out </a></li>
         </ul>


### PR DESCRIPTION
Because the username that links to the users profile now can collapse
into the avatar, we need a separate link that's always accessible.

This fixes #136 

<img width="210" alt="screenshot 2017-02-28 01 32 47" src="https://cloud.githubusercontent.com/assets/610925/23387658/dbd5b12a-fd55-11e6-9b57-e45bded0a018.png">

<img width="453" alt="screenshot 2017-02-28 01 32 39" src="https://cloud.githubusercontent.com/assets/610925/23387659/dea64a18-fd55-11e6-8b55-6ac111dbce82.png">
