### PR TITLE
Display errors when evaluating or running dweets

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -10,6 +10,7 @@
       color: red;
       font-size: small;
       position: absolute;
+      font-family: sans-serif;
       top: 1em;
       left: 1em;
     }

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -6,6 +6,13 @@
       width: 100%;
       background: white;
       }
+    .error-display {
+      color: red;
+      font-size: small;
+      position: absolute;
+      top: 1em;
+      left: 1em;
+    }
     </style>
     <script>
       var autoplay = getURLParameter('autoplay');
@@ -42,8 +49,19 @@
         }
       }
 
+      function displayError(e) {
+        document.querySelector(".error-display").innerHTML = e;
+      }
+
       function newCode(code) {
-          eval("u = function(t){"+code+"};")
+          try {
+            eval("u = function(t){"+code+"};")
+          } catch (e) {
+            displayError(e);
+            u = function(t){}; // prevent loop() from calling displayError
+            throw e;
+          }
+          displayError("");
           reset();
       }
 
@@ -76,6 +94,7 @@
   </head>
 <body>
   <canvas id=c></canvas>
+  <div class=error-display></div>
   <script>
     var c = document.querySelector("#c");
     c.width = 1920;
@@ -103,7 +122,12 @@
       }
       frame++;
 
-      u(time);
+      try {
+        u(time);
+      } catch (e) {
+        displayError(e);
+        throw e;
+      }
     }
     if(autoplay) {
         loop();


### PR DESCRIPTION
Now you don't have to open dev console to see errors! (Addresses #77.)

The error div is contained inside the dweet iframe, so the iframe now has both a canvas and a div. Dweet code can potentially select and modify the div but this shouldn't be harmful.

Demo:
![demo](https://cloud.githubusercontent.com/assets/6273197/23387674/ee23ca76-fd12-11e6-8252-d9fa26c65a1e.gif)