### PR TITLE
Reduce user menu hover target

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -274,13 +274,14 @@ iframe {
 }
 
 .head-account-info .collapsible {
-  opacity: 0;
   position: absolute;
   border: 1px solid #ddd;
   right: 1em;
-  margin-top: -4px;
-  transition: all 0.05s;
   z-index: 10;
+  transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
+  opacity: 0;
+  height: 0;
+  margin-top: -9999px;
 }
 
 .head-account-info.is-logged-in:hover {
@@ -290,7 +291,8 @@ iframe {
 .head-account-info.is-logged-in:hover .collapsible {
   display: block;
   opacity: 1;
-  margin-top: 6px;
+  margin-top: 4px;
+  transition: opacity 0.05s ease-in-out, margin 0.05s step-start;
 }
 
 .head-account-info .collapsible li {


### PR DESCRIPTION
Before this commit, you could hover over the invisible parts of the drop
down menu to make it visible. That was a problem because the invisible
part would cover the "hot/new/top" links on small screens, making them
unclickable. Now, only the username/avatar can be hovered over to
trigger the menu.

Before:

![](https://i.gyazo.com/4ff7625dea75f2a7c6829578edafef61.gif)

After:

![](https://i.gyazo.com/ef44bb82c712d43a6c8de8f8623ffba0.gif)