### PR TITLE
Fix dweets with comments

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -56,7 +56,7 @@
 
       function newCode(code) {
           try {
-            eval("u = function(t){"+code+"};")
+            eval("u = function(t){"+code+"\n};")
           } catch (e) {
             displayError(e);
             u = function(t){}; // prevent loop() from calling displayError


### PR DESCRIPTION
When we introduced error display, we accidentally killed dweets that end
with a line comment. This rectifies the issue.