### PR TITLE
Add urlizing to comments

### DIFF
--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -98,7 +98,7 @@
       {% if comment != dweet.comments.last or dweet.comments.last.author != dweet.author  %}
       <li class=comment>
       <a class=comment-name href="{% url 'user_feed' url_username=comment.author.username %}">{{ comment.author.username }}:</a>
-      <span class="comment-message">{{ comment.text }}</span>
+      <span class="comment-message">{{ comment.text | urlizetrunc:45 }}</span>
       </li>
       {% endif %}
       {% endfor %}


### PR DESCRIPTION
Urls are visually truncated at 45 characters.

![image](https://cloud.githubusercontent.com/assets/578029/23436638/88592700-fe0b-11e6-937b-b3f4187a8a15.png)
