### PR TITLE
Erase error message whenever if u() doesn't throw an error

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -58,8 +58,9 @@
           try {
             eval("u = function(t){"+code+"\n};")
           } catch (e) {
-            displayError(e);
-            u = function(t){}; // prevent loop() from calling displayError
+            u = function(t){
+              throw e;
+            };
             throw e;
           }
           displayError("");
@@ -125,6 +126,7 @@
 
       try {
         u(time);
+        displayError("");
       } catch (e) {
         displayError(e);
         throw e;


### PR DESCRIPTION
See #138: https://www.dwitter.net/d/1521 prints an error on the first loop but doesn't in subsequent loops.


