### PR TITLE
Remove "new dweet" box on user page

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -87,6 +87,7 @@ def feed(request, page_nr, sort):
                'next_url': next_url,
                'prev_url': prev_url,
                'sort': sort,
+               'show_submit_box': True
                }
     return render(request, 'feed/feed.html', context)
 

--- a/dwitter/templates/feed/feed.html
+++ b/dwitter/templates/feed/feed.html
@@ -50,7 +50,9 @@
 
 <div class=dweet-feed>
 
+  {% if show_submit_box %}
   {% include 'snippets/new_dweet_card.html' %}
+  {% endif %}
 
   {% for dweet in dweet_list %}
     {% include 'snippets/dweet_card.html' %}

--- a/dwitter/user/views.py
+++ b/dwitter/user/views.py
@@ -78,6 +78,7 @@ def user_feed(request, url_username, page_nr, sort, dweets=None, url=None):
                'on_last_page': last == dweet_count,
                'next_url': next_url,
                'prev_url': prev_url,
+               'show_submit_box': False,
                }
     return render(request, 'feed/feed.html', context)
 


### PR DESCRIPTION
The submit new dweet box is only needed on the main page and is quite
distracting in the other feeds