### PR TITLE
rename _author back to author

### DIFF
--- a/dwitter/migrations/0013_auto_20170305_1830.py
+++ b/dwitter/migrations/0013_auto_20170305_1830.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+import dwitter.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('dwitter', '0012_auto_20170228_2305'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='comment',
+            old_name='_author',
+            new_name='author',
+        ),
+        migrations.RenameField(
+            model_name='dweet',
+            old_name='_author',
+            new_name='author',
+        ),
+        migrations.AlterField(
+            model_name='dweet',
+            name='author',
+            field=models.ForeignKey(on_delete=models.SET(dwitter.models.get_sentinel_user), blank=True, to=settings.AUTH_USER_MODEL, null=True),
+        ),
+    ]

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -12,7 +12,7 @@ def get_sentinel_user():
 
 @receiver(pre_delete, sender=User)
 def soft_delete_user_dweets(instance, **kwargs):
-    for dweet in Dweet.objects.filter(_author=instance):
+    for dweet in Dweet.objects.filter(author=instance):
         dweet.delete()
 
 
@@ -32,16 +32,8 @@ class Dweet(models.Model):
     hotness = models.FloatField(default=1.0)
     deleted = models.BooleanField(default=False)
 
-    _author = models.ForeignKey(User, on_delete=models.SET_NULL,
-                                null=True, blank=True)
-
-    @property
-    def author(self):
-        return self._author or get_sentinel_user()
-
-    @author.setter
-    def author(self, value):
-        self._author = value
+    author = models.ForeignKey(User, on_delete=models.SET(get_sentinel_user),
+                               null=True, blank=True)
 
     objects = NotDeletedDweetManager()
     with_deleted = models.Manager()
@@ -62,15 +54,7 @@ class Comment(models.Model):
     posted = models.DateTimeField()
     reply_to = models.ForeignKey(Dweet, on_delete=models.CASCADE,
                                  related_name="comments")
-    _author = models.ForeignKey(User, on_delete=models.CASCADE)
-
-    @property
-    def author(self):
-        return self._author
-
-    @author.setter
-    def author(self, value):
-        self._author = value
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
 
     def __unicode__(self):
         return ('c/' +

--- a/dwitter/tests/dweet/test_dweet_views.py
+++ b/dwitter/tests/dweet/test_dweet_views.py
@@ -23,7 +23,7 @@ class DweetTestCase(TransactionTestCase):
         self.dweet = Dweet.objects.create(id=1,
                                           code="dweet code",
                                           posted=timezone.now(),
-                                          _author=self.user)
+                                          author=self.user)
 
     def test_fullscreen_dweet_returns_404_if_dweet_does_not_exist(self):
         response = self.client.get('/id/2')

--- a/dwitter/tests/models/test_comment.py
+++ b/dwitter/tests/models/test_comment.py
@@ -16,25 +16,25 @@ class DweetTestCase(TestCase):
         dweet1 = Dweet.objects.create(id=1,
                                       code="dweet1 code",
                                       posted=now - timedelta(minutes=1),
-                                      _author=user1)
+                                      author=user1)
 
         dweet2 = Dweet.objects.create(id=2,
                                       code="dweet2 code",
                                       posted=now,
                                       reply_to=dweet1,
-                                      _author=user2)
+                                      author=user2)
 
         Comment.objects.create(id=1,
                                text="comment1 text",
                                posted=now - timedelta(minutes=1),
                                reply_to=dweet2,
-                               _author=user1)
+                               author=user1)
 
         Comment.objects.create(id=2,
                                text="comment2 text",
                                posted=now,
                                reply_to=dweet1,
-                               _author=user2)
+                               author=user2)
 
     def test_comment_renders_to_string_correctly(self):
         self.assertEqual(Comment.objects.get(id=1).__unicode__(),

--- a/dwitter/tests/models/test_dweet.py
+++ b/dwitter/tests/models/test_dweet.py
@@ -15,13 +15,13 @@ class DweetTestCase(TestCase):
         dweet1 = Dweet.objects.create(id=1,
                                       code="dweet1 code",
                                       posted=now - timedelta(minutes=1),
-                                      _author=user1)
+                                      author=user1)
 
         dweet2 = Dweet.objects.create(id=2,
                                       code="dweet2 code",
                                       posted=now,
                                       reply_to=dweet1,
-                                      _author=user2)
+                                      author=user2)
         dweet2.likes.add(user1, user2)
 
     def test_dweet_renders_to_string_correctly(self):

--- a/dwitter/user/views.py
+++ b/dwitter/user/views.py
@@ -34,7 +34,7 @@ def user_feed(request, url_username, page_nr, sort, dweets=None, url=None):
     first = (page - 1) * dweets_per_page
     last = page * dweets_per_page
     if not dweets:
-        dweets = Dweet.objects.filter(_author=user)
+        dweets = Dweet.objects.filter(author=user)
     dweet_count = dweets.count()
     total_awesome = dweets.annotate(
         num_likes=Count('likes')).aggregate(
@@ -45,7 +45,7 @@ def user_feed(request, url_username, page_nr, sort, dweets=None, url=None):
         last = dweet_count
 
     if not dweets:
-        dweet_list = Dweet.objects.filter(_author=user)
+        dweet_list = Dweet.objects.filter(author=user)
     else:
         dweet_list = dweets
 

--- a/dwitter/views.py
+++ b/dwitter/views.py
@@ -8,9 +8,9 @@ from rest_framework import viewsets, permissions
 class CommentViewSet(viewsets.ModelViewSet):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
-    filter_fields = ('reply_to', '_author')
+    filter_fields = ('reply_to', 'author')
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,
                           IsAuthorOrReadOnly, )
 
     def perform_create(self, serializer):
-        serializer.save(_author=self.request.user, posted=timezone.now())
+        serializer.save(author=self.request.user, posted=timezone.now())


### PR DESCRIPTION
On its own, this PR could lead to 500 errors occurring. Dweets with an author whose account was deleted before the migration would now have a `NULL` author, with no defaulting to `get_sentinel_user`. To fix this, I'd suggest running the following script before doing the migration:

```py
import os

os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dwitter.settings")

import django
from dwitter.models import Dweet
from dwitter.models import get_sentinel_user

django.setup()

for dweet in Dweet.with_deleted.filter(author=None):
    author = get_sentinel_user()
```