### PR TITLE
wrap long comments, even if they contain code

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -160,6 +160,11 @@ ul.messages {
   font-weight:bold;
 }
 
+.comment-message {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
 .new-comment {
   margin-top: 10px;
   display: flex;


### PR DESCRIPTION
Fixes https://github.com/lionleaf/dwitter/issues/90.

`word-wrap` is for IE compatibility.

Demo:

![image](https://cloud.githubusercontent.com/assets/8731922/23639396/808e22b0-02b5-11e7-9282-dd7b7f0a5b50.png)
