### PR TITLE
Remove top margin on remix button

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -392,7 +392,6 @@ form.like {
 
 .dweet-changed {
   display: none;
-  margin-top: 30px;
   text-align: right;
   color: white;
 }


### PR DESCRIPTION
When resolving a merge conflict in #170, I re-introduced a line of CSS that should have been removed. This PR removes that line.