### PR TITLE
Make link to Dwitter frontpage always say Dwitter

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -80,7 +80,6 @@ def feed(request, page_nr, sort):
         raise Http404("No such sorting method " + sort)
 
     context = {'dweet_list': dweet_list,
-               'header_title': 'Dwitter',
                'feed_type': 'all',
                'page_nr': page,
                'on_last_page': last == dweet_count,
@@ -96,8 +95,7 @@ def dweet_show(request, dweet_id):
     dweet = get_object_or_404(Dweet.with_deleted, id=dweet_id)
 
     context = {
-        'dweet': dweet,
-        'header_title': 'Dwitter',
+        'dweet': dweet
     }
 
     return render(request, 'feed/permalink.html', context)

--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -50,7 +50,10 @@
         {% endif %}
       </div>
       <div class=header-center-div>
-        <h2 class=header-title><a  href="{% url 'root' %}">{% block header_title %}Dwitter{% endblock %}</a></h2>
+        <h2 class=header-title>
+          <a href="{% url 'root' %}">Dwitter</a>
+          {% block header_title %}{% endblock %}
+        </h2>
         <br />
         {% block top-nav %}
         {% endblock %}

--- a/dwitter/templates/feed/feed.html
+++ b/dwitter/templates/feed/feed.html
@@ -18,7 +18,11 @@
 
 
 {% block header_title %}
-{{ header_title }}
+  {% if feed_type == "user" %}
+    | <a href="{% url 'user_feed' url_username=feed_user %}">
+    {{ header_title }}
+    </a>
+  {% endif %}
 {% endblock %}
 
 {% block top-nav %}


### PR DESCRIPTION
A separate link to refresh the user feed is now shown on user pages.

This fixes #118.