### PR TITLE
Hide new dweet box

### DIFF
--- a/dwitter/static/js/feed.js
+++ b/dwitter/static/js/feed.js
@@ -57,4 +57,13 @@ $(document).ready(function()  {
     var postedDate = moment.utc($(element).text(), 'MMM D YYYY h:mm A [UTC]');
     $(element).text(postedDate.local().format('lll'));
   });
+
+  $('.dweet-create-form-title').click(function() {
+    $(this).hide();
+    var dweet = $('.submit-box').slideDown();
+    registerOnKeyListener(dweet);
+    var iframe =  $(dweet).find(".dweetiframe")[0];
+    registerWaypoint(iframe);
+    var textarea = $(dweet).find('textarea').focus();
+  });
 });

--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -53,25 +53,6 @@ window.onload = function() {
     registerWaypoint(iframe);
   });
 
-  function registerWaypoint(iframe){
-    console.log("Registering " + iframe.src);
-    var inview = new Waypoint.Inview({
-      element: iframe,
-        entered: function(dir) {
-          play(iframe)
-        },
-        exit: function(dir) {
-          var fullscreenElement = (document.fullscreenElement ||
-              document.webkitFullscreenElement ||
-              document.mozFullScreenElement);
-          if(fullscreenElement != iframe) {
-            pause(iframe)
-          }
-        },
-    });
-
-  }
-
   var dweets = document.querySelectorAll(".dweet");
   [].forEach.call(dweets, function(dweet) {
     registerOnKeyListener(dweet);
@@ -91,51 +72,68 @@ window.onload = function() {
     showCode(editoriframe, editor.value);
     oldCode = editor.value;
   });
-
-  function play(iframe){
-    dweetwin =  iframe.contentWindow || iframe;
-    dweetwin.postMessage("play","*");
-    console.log("Send play to " + iframe.src);
-  }
-  function pause(iframe){
-    dweetwin =  iframe.contentWindow || iframe;
-    dweetwin.postMessage("pause","*");
-    console.log("Send pause to " + iframe.src);
-  }
-
-  function showCode(iframe, code) {
-    dweetwin =  iframe.contentWindow || iframe;
-    dweetwin.postMessage("code "+code,'*');
-  }
-
-  function setEditing(iframe) {
-    (iframe.contentWindow || iframe).postMessage("editing", "*");
-  }
-
-  function registerOnKeyListener(dweet){
-    var iframe = $(dweet).find('.dweetiframe')[0];
-    var editor = $(dweet).find('.code-input')[0];
-    var changedDweetMenu = $(dweet).find('.dweet-changed');
-    var oldCode = editor.value;
-    var originalCode = oldCode;
-
-    showCode(iframe, oldCode);
-    editor.addEventListener('keyup', function() {
-      setEditing(iframe);
-
-      if(editor.value == originalCode){
-        changedDweetMenu.hide();
-      }else{
-        changedDweetMenu.show();
-      }
-
-      if(editor.value == oldCode) {
-        return;
-      }
-      editor.size = Math.max(editor.value.length, 1);
-      showCode(iframe, editor.value);
-      oldCode = editor.value;
-    });
-
-  }
 };
+
+function registerWaypoint(iframe){
+  console.log("Registering " + iframe.src);
+  var inview = new Waypoint.Inview({
+    element: iframe,
+      entered: function(dir) {
+        play(iframe)
+      },
+      exit: function(dir) {
+        var fullscreenElement = (document.fullscreenElement ||
+            document.webkitFullscreenElement ||
+            document.mozFullScreenElement);
+        if(fullscreenElement != iframe) {
+          pause(iframe)
+        }
+      },
+  });
+}
+
+function play(iframe){
+  dweetwin =  iframe.contentWindow || iframe;
+  dweetwin.postMessage("play","*");
+  console.log("Send play to " + iframe.src);
+}
+function pause(iframe){
+  dweetwin =  iframe.contentWindow || iframe;
+  dweetwin.postMessage("pause","*");
+  console.log("Send pause to " + iframe.src);
+}
+
+function showCode(iframe, code) {
+  dweetwin =  iframe.contentWindow || iframe;
+  dweetwin.postMessage("code "+code,'*');
+}
+
+function setEditing(iframe) {
+  (iframe.contentWindow || iframe).postMessage("editing", "*");
+}
+
+function registerOnKeyListener(dweet){
+  var iframe = $(dweet).find('.dweetiframe')[0];
+  var editor = $(dweet).find('.code-input')[0];
+  var changedDweetMenu = $(dweet).find('.dweet-changed');
+  var oldCode = editor.value;
+  var originalCode = oldCode;
+
+  showCode(iframe, oldCode);
+  editor.addEventListener('keyup', function() {
+    setEditing(iframe);
+
+    if(editor.value == originalCode){
+      changedDweetMenu.hide();
+    }else{
+      changedDweetMenu.show();
+    }
+
+    if(editor.value == oldCode) {
+      return;
+    }
+    editor.size = Math.max(editor.value.length, 1);
+    showCode(iframe, editor.value);
+    oldCode = editor.value;
+  });
+}

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -198,6 +198,35 @@ input.comment-submit:active {
   border:1px solid #ddd;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
   padding: 15px;
+  display: none;
+}
+
+.dweet-create-form-title {
+  background: #4599ca;
+  color: white;
+  font-size: 1.1em;
+  cursor: pointer;
+  width: 50%;
+  font-weight: bold;
+  text-align: center;
+  padding: 10px;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+  margin: 0 auto;
+}
+
+.dweet-create-form-title:hover {
+  text-decoration: underline;
+}
+
+.dweet-create-form-title .add-icon {
+  background: white;
+  color: #4599ca;
+  border-radius: 50%;
+  width: 27px;
+  height: 27px;
+  display: inline-block;
+  margin-right: 10px;
 }
 
 .author-remix-wrapper{
@@ -219,6 +248,7 @@ input.comment-submit:active {
 .function-wrap {
   color:gray;
   font-size:small;
+  float: left;
 }
 
 .code-input{
@@ -456,7 +486,8 @@ body.hot .top-sort-list a.hot {
 #submit-preview {
 }
 
-#submit-help{
+.submit-help{
+  font-size: 0.8em;
 }
 
 .delete {
@@ -499,13 +530,11 @@ body.hot .top-sort-list a.hot {
   border-radius: 75px;
 }
 
-.dweet .dark-section {
-  margin-top: 20px;
-  margin-left: -15px;
-  margin-right: -15px;
-  margin-bottom: -15px;
+.dark-section {
+  margin: 20px -15px -15px;
   background: #222;
-  padding: 0 15px 15px;
+  padding: 15px;
+  overflow: hidden;
 }
 
 .dark-section .dweet-code textarea {
@@ -513,6 +542,8 @@ body.hot .top-sort-list a.hot {
   border: 0;
   color: white;
   outline: 0;
+  font-size: small;
+  padding: 0;
 }
 
 .dark-section .dweet-code textarea:focus {

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -40,17 +40,14 @@
     </div>
     <br>
     <div class="dark-section">
-        <code class="function-wrap">
-          function u(t){
-        </code>
+        <code class="function-wrap">function u(t){</code>
         <form action="{% url 'dweet_reply' dweet_id=dweet.id %}" method="post">
           {% csrf_token %}
           <div class=dweet-code>
             <textarea autocorrect="off" autocapitalize="off" spellcheck="false" name=code class=code-input rows=4 oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';">{{ dweet.code }}</textarea>
           </div>
           <p class=dweet-timestamp> {{ dweet.posted | date:"M j Y g:i A" }} UTC</p>
-          <code class="function-wrap">} //<div class=character-count>{{ dweet.code | length }}/140</div>
-          </code>
+          <code class="function-wrap">} //<div class=character-count>{{ dweet.code | length }}/140</div></code>
           <div class=dweet-changed>
             {% if request.user.is_authenticated %}
             <input

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -1,49 +1,45 @@
 {% load subdomainurls %}
+<div class="dweet-create-form-title"><span class="add-icon">+</span>Create new dweet</div>
 <div class=submit-box>
-  <div class=canvas-iframe-container-wrapper
+  <div
+    class=canvas-iframe-container-wrapper
     id="submit-preview">
-    <div class=canvas-iframe-container 
+    <div
+      class=canvas-iframe-container
       id="iframe-container-submit">
       <iframe class="dweetiframe" id=preview-iframe src="{% url 'blank_dweet' subdomain='dweet' %}" sandbox="allow-scripts"></iframe>
     </div>
   </div>
-  <div id=click-the-code>
-    <b>Edit the code to start the fun or browse through other people's demos below.</b>
-    Code available at <a href="http://github.com/lionleaf/dwitter">github.com/lionleaf/dwitter</a>. Issues are welcome! :D
+  <div class="dark-section">
+    <code class="function-wrap">function u(t){</code>
+    <form action="{% url 'dweet' %}" method="post">
+      {% csrf_token %}
+      <div class=dweet-code>
+        <textarea
+          autocorrect="off" autocapitalize="off" spellcheck="false"
+          name=code
+          class=code-input
+          rows=4
+          id=editor
+          oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';"
+          >c.width=1920; /* clear the canvas */
+  for(i=0;i<9;i++)
+  x.fillRect(400+i*100+S(t)*300, 400, 50, 200) /* draw 50x200 rects */</textarea>
+      </div>
+      <code class="function-wrap">} //<div class=character-count>122/140</div>
+      </code>
+      {% if request.user.is_authenticated %}
+        <input
+          class=dweet-button
+          type="submit"
+          value="Post dweet!" />
+      {% else %}
+        <p>Please <a href="{% url 'auth_login'  %}" >log in</a> (or <a href="{% url 'register'  %}" >register</a>) to post a dweet (copy-paste the code somewhere safe to save it meanwhile) </p>
+      {% endif %}
+    </form>
   </div>
-  <code>
-    function u(t){
-  </code>
-  <form action="{% url 'dweet' %}" method="post">
-    {% csrf_token %}
-    <div class=dweet-code>
-      <textarea
-        autocorrect="off" autocapitalize="off" spellcheck="false"
-        name=code
-        class=code-input
-        rows=4
-        id=editor
-        oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';"
-        >c.width=1920; /* clear the canvas */
-for(i=0;i<9;i++)
-x.fillRect(400+i*100+S(t)*300, 400, 50, 200) /* draw 50x200 rects */</textarea>
-      <div class=character-count>122/140</div>
-    </div>
-    <code>
-      }
-    </code>
-    <br />
-    {% if request.user.is_authenticated %}
-    <input  
-    class=dweet-button
-    type="submit" 
-    value="Dweet!" />
-    {% else %}
-    <p> Please <a href="{% url 'auth_login'  %}" >log in</a> (or <a href="{% url 'register'  %}" >register</a>) to post a dweet (copy-paste the code somewhere safe to save it meanwhile) </p>
-    {% endif %}
-  </form>
   <br />
-  <code id=submit-help>
+  <code class=submit-help>
     u(t) is called 60 times per second.
     t: Elapsed time in seconds.
     S: Shorthand for Math.sin.
@@ -51,6 +47,6 @@ x.fillRect(400+i*100+S(t)*300, 400, 50, 200) /* draw 50x200 rects */</textarea>
     T: Shorthand for Math.tan.
     R: Function that generates rgba-strings, usage ex.: R(255, 255, 255, 0.5)
     c: A 1920x1080 canvas.
-    x: A 2D context for that canvas. 
+    x: A 2D context for that canvas.
   </code>
 </div>


### PR DESCRIPTION
This hides the UI for creating a new dweet by default, so the first you see when entering the page is now instead the top dweet. To show the UI, you must click the 'create a new dweet' button at the top of the feed.

The UI for creating dweet is also cleaned up a little, to look more similar to dweet editing and remove visual noise.

This fixes #3.

<img width="879" alt="screenshot 2017-03-12 18 36 26" src="https://cloud.githubusercontent.com/assets/1413267/23834214/e8291be0-0752-11e7-87c5-d450983dbcd3.png">

<img width="760" alt="screenshot 2017-03-12 18 36 33" src="https://cloud.githubusercontent.com/assets/1413267/23834213/e58fc92e-0752-11e7-8a90-0b58e20ed65d.png">