### PR TITLE
add a link to enable/disable the FPS counter

### DIFF
--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -17,6 +17,7 @@ window.onload = function() {
 
         $.each(items, function(index, div){
           registerOnKeyListener(div);
+          registerStatsClickListeners(div);
           var iframe =  $(div).find(".dweetiframe")[0];
           registerWaypoint(iframe);
 
@@ -56,6 +57,7 @@ window.onload = function() {
   var dweets = document.querySelectorAll(".dweet");
   [].forEach.call(dweets, function(dweet) {
     registerOnKeyListener(dweet);
+    registerStatsClickListeners(dweet);
   });
 
 
@@ -108,8 +110,16 @@ function showCode(iframe, code) {
   dweetwin.postMessage("code "+code,'*');
 }
 
-function setEditing(iframe) {
-  (iframe.contentWindow || iframe).postMessage("editing", "*");
+function showStats(dweet, iframe) {
+  (iframe.contentWindow || iframe).postMessage("showStats", "*");
+  $(dweet).find('.show-stats').hide();
+  $(dweet).find('.hide-stats').show();
+}
+
+function hideStats(dweet, iframe) {
+  (iframe.contentWindow || iframe).postMessage("hideStats", "*");
+  $(dweet).find('.show-stats').show();
+  $(dweet).find('.hide-stats').hide();
 }
 
 function registerOnKeyListener(dweet){
@@ -121,7 +131,7 @@ function registerOnKeyListener(dweet){
 
   showCode(iframe, oldCode);
   editor.addEventListener('keyup', function() {
-    setEditing(iframe);
+    showStats(dweet, iframe);
 
     if(editor.value == originalCode){
       changedDweetMenu.hide();
@@ -135,5 +145,15 @@ function registerOnKeyListener(dweet){
     editor.size = Math.max(editor.value.length, 1);
     showCode(iframe, editor.value);
     oldCode = editor.value;
+  });
+}
+
+function registerStatsClickListeners(element) {
+  var iframe = $(element).find('.dweetiframe')[0];
+  $(element).find('.show-stats').click(function() {
+    showStats(element, iframe);
+  });
+  $(element).find('.hide-stats').click(function() {
+    hideStats(element, iframe);
   });
 }

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -41,6 +41,8 @@ input[type=submit].dweet-button {
 }
 
 input[type=submit].remix-button {
+  float: right;
+  clear: both;
   margin-top: 5px;
 }
 
@@ -441,17 +443,24 @@ form.like {
   text-align: left;
 }
 
-.fullscreen-button, .share-button {
-  text-align:right;
-  float:right;
+.show-stats, .hide-stats {
+  display: none;
+}
+
+.hide-stats.visible {
+  display: initial;
+}
+
+.fullscreen-button, .share-button, .show-stats, .hide-stats {
+  flex-grow: 0;
   padding:5px;
 }
 
 .share-link {
   width:15em;
-  float:right;
-  clear:both;
   display:none;
+  position: absolute;
+  top: 2em;
 }
 
 .dweet-timestamp{
@@ -464,8 +473,17 @@ form.like {
 }
 
 .dweet-actions {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
   margin-top:10px;
   margin-bottom:20px;
+  position: relative;
+}
+
+.dweet-actions > form.like {
+  flex-grow: 1;
+  margin: auto 0;
 }
 
 .top-sort-list {
@@ -563,7 +581,6 @@ body.hot .top-sort-list a.hot {
 }
 
 .dweet-delete-form {
-  float: right;
   display: inline-block;
   vertical-align: middle;
   padding: 3px;

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -40,8 +40,11 @@
           case "pause":
             pauseDemo();
             break;
-          case "editing":
+          case "showStats":
             setStatsVisibility(true);
+            break;
+          case "hideStats":
+            setStatsVisibility(false);
             break;
         }
 

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -14,7 +14,11 @@
           <span class="like-text">Awesome!</span>
         </button>
       </form>
-        {% if request.user == dweet.author or request.user.is_staff %}
+      <a class="show-stats" href="javascript:;" target="_blank">show FPS</a>
+      <a class="hide-stats" href="javascript:;" target="_blank">hide FPS</a>
+      <a class=fullscreen-button href="javascript:;" target="_blank">fullscreen</a>
+      <a class=share-button href="javascript:;" target="_blank">share</a>
+      {% if request.user == dweet.author or request.user.is_staff %}
         <form class="dweet-delete-form" action="{% url 'dweet_delete' dweet_id=dweet.id %}" method="post"
           onsubmit="return confirm('Are you sure you want to delete the dweet (cannot be reversed)?');" >
           {% csrf_token %}
@@ -23,10 +27,7 @@
           type="submit"
           value="delete" />
         </form>
-        {% endif %}
-      <a class=fullscreen-button href="javascript:;" target="_blank">fullscreen</a>
-      <a class=share-button href="javascript:;" target="_blank">share</a>
-      <br />
+      {% endif %}
       <input type=text readonly class=share-link value='{% url 'dweet_show' dweet_id=dweet.id %}'/>
     </div>
     <div class=author-remix-wrapper>

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -1,6 +1,6 @@
 {% load subdomainurls %}
 <div class="dweet-create-form-title"><span class="add-icon">+</span>Create new dweet</div>
-<div class=submit-box>
+<div class="dweet submit-box">
   <div
     class=canvas-iframe-container-wrapper
     id="submit-preview">
@@ -9,6 +9,10 @@
       id="iframe-container-submit">
       <iframe class="dweetiframe" id=preview-iframe src="{% url 'blank_dweet' subdomain='dweet' %}" sandbox="allow-scripts"></iframe>
     </div>
+  </div>
+  <div class="dweet-actions">
+    <a class="show-stats" href="javascript:;" target="_blank">show FPS</a>
+    <a class="hide-stats visible" href="javascript:;" target="_blank">hide FPS</a>
   </div>
   <div class="dark-section">
     <code class="function-wrap">function u(t){</code>


### PR DESCRIPTION
This closes https://github.com/lionleaf/dwitter/issues/182.

Demo:
![show-hide-fps-counter](https://cloud.githubusercontent.com/assets/8731922/23837778/04bb4182-0764-11e7-842d-6248ed5acfdf.gif)

The dweet-sharing link:

![image](https://cloud.githubusercontent.com/assets/8731922/23837775/fe83cc1c-0763-11e7-82e3-cff4385b7cd5.png)
