### PR TITLE
Add Javascript linting (part 1)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,27 @@
+extends:
+  - defaults/configurations/airbnb/es5
+rules:
+  no-empty-label: off
+  space-after-keywords: off
+  space-return-throw-case: off
+  no-labels: error
+  keyword-spacing: error
+  space-before-function-paren:
+    - error
+    - never
+  comma-dangle:
+    - error
+    - always-multiline
+  no-multiple-empty-lines:
+    - error
+    - max: 1
+  indent:
+    - error
+    - 2
+env:
+  browser: true
+  jquery: true
+globals:
+  Waypoint: false
+  moment: false
+  Stats: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.log
 *.pot
 *.pyc
-.*
 dwitter/settings/local.py
 dwitter/static/CACHE/*
 dwitter/static/admin/*
@@ -12,3 +11,4 @@ venv/*
 backups/*
 *.iml
 backup*.json
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ run:
 .PHONY: update
 update:
 	pip install --upgrade -r requirements.txt
+	npm install
 
 .PHONY: migrate
 migrate:
@@ -47,4 +48,3 @@ clean:
 	find . -name '*.pyc' -delete
 	find . -name '__pycache__' -delete
 	find . -type d -empty -delete
-

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Inspired by [arkt.is/t/](http://arkt.is/t/Yy53aWR0aD0yZTM7eC5maWxsUmVjdCgxNTAsMT
 Current build: [dwitter.net](http://dwitter.net)
 
 ## Pre-requisites and first-time installation
+* Install `npm`
 * `sudo apt install git virtualenv python-pip`
 * `git clone https://github.com/lionleaf/dwitter.git`
 

--- a/dwitter/static/js/ajax-handling.js
+++ b/dwitter/static/js/ajax-handling.js
@@ -1,32 +1,32 @@
-var processLike = function(e)  {
+var processLike = function(e) {
   e.preventDefault();
   var $likeForm = $(this);
   var dweet_id = $likeForm.data('dweet_id');
   var $like_button = $likeForm.find('.like-button');
-   var processServerResponse = function(serverResponse_json, textStatus_ignored,
-       jqXHR_ignored)  {
-     if(serverResponse_json.not_authenticated){
-       window.location = "/accounts/login/";
-     }else{
-       $like_button.find('.score-text').html(serverResponse_json.likes);
-       if(serverResponse_json.liked){
-         $like_button.addClass('liked');
-       }else{
-         $like_button.removeClass('liked');
-       }
-     }
-   }
+  var processServerResponse = function(serverResponse_json, textStatus_ignored,
+       jqXHR_ignored) {
+    if (serverResponse_json.not_authenticated) {
+      window.location = '/accounts/login/';
+    } else {
+      $like_button.find('.score-text').html(serverResponse_json.likes);
+      if (serverResponse_json.liked) {
+        $like_button.addClass('liked');
+      } else {
+        $like_button.removeClass('liked');
+      }
+    }
+  };
 
-   var config = {
-     url: '/d/' + dweet_id + '/like',
-     dataType: 'json',
-      method: 'POST',
-      headers: {
-        'X-CSRFToken': $likeForm.data('csrf'),
-      },
-      success: processServerResponse,
-   };
-   $.ajax(config);
+  var config = {
+    url: '/d/' + dweet_id + '/like',
+    dataType: 'json',
+    method: 'POST',
+    headers: {
+      'X-CSRFToken': $likeForm.data('csrf'),
+    },
+    success: processServerResponse,
+  };
+  $.ajax(config);
 };
 
 var getCommentHTML = function(comment) {
@@ -38,43 +38,42 @@ var getCommentHTML = function(comment) {
 
 var loadComments = function() {
   var step = 1000;
-  var current_offset = $(this).data('offset') ;
+  var current_offset = $(this).data('offset');
 
   var $load_comments_button = $(this);
 
-   var dweet_id = $load_comments_button.data('dweet_id');
-   var next = $load_comments_button.data('next');
-   //If there is a sticky comment on the top of the comments
-   var sticky_top = $load_comments_button.data('sticky_top');
+  var dweet_id = $load_comments_button.data('dweet_id');
+  var next = $load_comments_button.data('next');
+   // If there is a sticky comment on the top of the comments
+  var sticky_top = $load_comments_button.data('sticky_top');
 
-   var loadCommentsResponse = function(serverResponse_json, textStatus_ignored,
-       jqXHR_ignored)  {
+  var loadCommentsResponse = function(serverResponse_json, textStatus_ignored,
+       jqXHR_ignored) {
+    var $comment_section = $load_comments_button.parents('.comments');
 
-     var $comment_section = $load_comments_button.parents('.comments');
+    if (serverResponse_json.next) {
+      alert('Woops, there are more comments, but they are unloadable as of now. Please bug lionleaf to fix');
+    } else {
+      $load_comments_button.parents('.comment').hide();
+    }
+    var new_comment_list = '';
+    for (var i in serverResponse_json.results.reverse()) {
+      var comment = serverResponse_json.results[i];
+      if (sticky_top && i == 0) {
+        continue; // Hack that works for now to avoid reloading the first comment if it was sticky
+      }
+      new_comment_list += getCommentHTML(comment);
+    }
+    $comment_section[0].innerHTML = new_comment_list + $comment_section[0].innerHTML;
+  };
 
-     if(serverResponse_json.next){
-       alert("Woops, there are more comments, but they are unloadable as of now. Please bug lionleaf to fix");
-     }else{
-       $load_comments_button.parents('.comment').hide();
-     }
-     var new_comment_list = '';
-     for(var i in serverResponse_json.results.reverse()){
-       var comment = serverResponse_json.results[i];
-       if(sticky_top && i == 0){
-         continue; //Hack that works for now to avoid reloading the first comment if it was sticky
-       }
-       new_comment_list  += getCommentHTML(comment);
-     }
-     $comment_section[0].innerHTML = new_comment_list + $comment_section[0].innerHTML;
-   }
-
-   var config = {
-     url: '/api/comments/?offset='+current_offset+'&limit='+step+'&format=json&reply_to='+dweet_id,
-     dataType: 'json',
-      success: loadCommentsResponse,
-   };
-   $.ajax(config);
-}
+  var config = {
+    url: '/api/comments/?offset=' + current_offset + '&limit=' + step + '&format=json&reply_to=' + dweet_id,
+    dataType: 'json',
+    success: loadCommentsResponse,
+  };
+  $.ajax(config);
+};
 
 var postComment = function(e) {
   e.preventDefault();
@@ -85,22 +84,21 @@ var postComment = function(e) {
   var $comment_section = $postForm.closest('.comment-section').children('.comments');
 
   var postCommentSuccess = function(serverResponse_json, textStatus_ignored,
-      jqXHR_ignored)  {
-
+      jqXHR_ignored) {
     $comment_text[0].value = '';
-    $comment_section[0].innerHTML =  $comment_section[0].innerHTML + getCommentHTML(serverResponse_json);
-  }
+    $comment_section[0].innerHTML = $comment_section[0].innerHTML + getCommentHTML(serverResponse_json);
+  };
 
   var postCommentError = function(serverResponse_json, textStatus_ignored,
-      jqXHR_ignored)  {
-    //Do nothing at the moment. TODO: Clearer error message displayed to the user?
-  }
+      jqXHR_ignored) {
+    // Do nothing at the moment. TODO: Clearer error message displayed to the user?
+  };
 
   var comment = {
     reply_to: dweet_id,
     text: $comment_text[0].value,
     csrfmiddlewaretoken: csrf,
-  }
+  };
 
   var config = {
     url: '/api/comments/',
@@ -110,11 +108,10 @@ var postComment = function(e) {
     data: comment,
   };
   $.ajax(config);
-}
+};
 
-
-$(document).ready(function()  {
-  $('body').on('submit','form.like', processLike);
-  $('body').on('click','.load-comments-link', loadComments);
-  $('body').on('submit','.new-comment', postComment);
+$(document).ready(function() {
+  $('body').on('submit', 'form.like', processLike);
+  $('body').on('click', '.load-comments-link', loadComments);
+  $('body').on('submit', '.new-comment', postComment);
 });

--- a/dwitter/static/js/feed.js
+++ b/dwitter/static/js/feed.js
@@ -1,12 +1,12 @@
 var onDweetChanged = function() {
-  var charCount = $(this).parent().parent().parent().find(".character-count")[0];
-  var submitButton = $(this).parent().parent().find(".remix-button")[0];
+  var charCount = $(this).parent().parent().parent().find('.character-count')[0];
+  var submitButton = $(this).parent().parent().find('.remix-button')[0];
 
   charCount.textContent = this.value.length + '/140';
-  if(this.value.length > 140){
+  if (this.value.length > 140) {
     $(charCount).addClass('too-long');
     $(submitButton).prop('disabled', true);
-  }else{
+  } else {
     $(charCount).removeClass('too-long');
     $(submitButton).prop('disabled', false);
   }
@@ -16,10 +16,9 @@ $(document).ajaxComplete(function() {
   $('.code-input').each(onDweetChanged);
 });
 
-$(document).ready(function()  {
-  $('body').on('input','.code-input', onDweetChanged);
+$(document).ready(function() {
+  $('body').on('input', '.code-input', onDweetChanged);
   $('.code-input').each(onDweetChanged);
-
 
   function requestFullscreen(el) {
     (el.mozRequestFullScreen ||
@@ -39,17 +38,15 @@ $(document).ready(function()  {
     sharebutt.on('click', function(e) {
       e.preventDefault();
       sharelink.toggle();
-      if(sharelink.is(":visible")){
+      if (sharelink.is(':visible')) {
         sharelink.select();
       }
     });
     $(sharelink).focus(function() {
-      $(this).on("click.a keyup.a", function(e){
-        $(this).off("click.a keyup.a").select();
+      $(this).on('click.a keyup.a', function(e) {
+        $(this).off('click.a keyup.a').select();
       });
     });
-
-
   });
 
   moment.locale(navigator.userLanguage || navigator.language || 'en-US');
@@ -62,7 +59,7 @@ $(document).ready(function()  {
     $(this).hide();
     var dweet = $('.submit-box').slideDown();
     registerOnKeyListener(dweet);
-    var iframe =  $(dweet).find(".dweetiframe")[0];
+    var iframe = $(dweet).find('.dweetiframe')[0];
     registerWaypoint(iframe);
     var textarea = $(dweet).find('textarea').focus();
   });

--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -1,65 +1,63 @@
 window.onload = function() {
-
   var infinite = new Waypoint.Infinite({
     element: $('.dweet-feed')[0],
-      items: '.dweet-wrapper, .loading, .end-of-feed',
-      more: '.next-page',
-      onAfterPageLoad: function(items) {
-        $('.loading:not(:last-of-type)').hide();
+    items: '.dweet-wrapper, .loading, .end-of-feed',
+    more: '.next-page',
+    onAfterPageLoad: function(items) {
+      $('.loading:not(:last-of-type)').hide();
 
-        var dwiframes = [];
+      var dwiframes = [];
 
-        function requestFullscreen(el) {
-          (el.mozRequestFullScreen ||
+      function requestFullscreen(el) {
+        (el.mozRequestFullScreen ||
            el.webkitRequestFullscreen ||
            el.requestFullscreen).call(el);
-        }
+      }
 
-        $.each(items, function(index, div){
-          registerOnKeyListener(div);
-          registerStatsClickListeners(div);
-          var iframe =  $(div).find(".dweetiframe")[0];
-          registerWaypoint(iframe);
+      $.each(items, function(index, div) {
+        registerOnKeyListener(div);
+        registerStatsClickListeners(div);
+        var iframe = $(div).find('.dweetiframe')[0];
+        registerWaypoint(iframe);
 
-          //Register full-screen button
-          var link = $(div).find('.fullscreen-button');
-          link.on('click', function(e) {
-            e.preventDefault();
-            requestFullscreen(iframe);
-          });
+          // Register full-screen button
+        var link = $(div).find('.fullscreen-button');
+        link.on('click', function(e) {
+          e.preventDefault();
+          requestFullscreen(iframe);
+        });
 
-          var sharebutt = $(div).find('.share-button');
-          var sharelink = $(div).find('.share-link');
-          sharebutt.on('click', function(e) {
-            e.preventDefault();
-            sharelink.toggle();
+        var sharebutt = $(div).find('.share-button');
+        var sharelink = $(div).find('.share-link');
+        sharebutt.on('click', function(e) {
+          e.preventDefault();
+          sharelink.toggle();
 
-            if(sharelink.is(":visible")){
-              sharelink.select();
-            }
-          });
+          if (sharelink.is(':visible')) {
+            sharelink.select();
+          }
+        });
 
-          $(sharelink).focus(function() {
-            $(this).on("click.a keyup.a", function(e){
-              $(this).off("click.a keyup.a").select();
-            });
+        $(sharelink).focus(function() {
+          $(this).on('click.a keyup.a', function(e) {
+            $(this).off('click.a keyup.a').select();
           });
         });
-      }
+      });
+    },
   });
 
-  var dweetiframes = document.querySelectorAll(".dweetiframe");
+  var dweetiframes = document.querySelectorAll('.dweetiframe');
 
-  [].forEach.call(dweetiframes, function(iframe){
+  [].forEach.call(dweetiframes, function(iframe) {
     registerWaypoint(iframe);
   });
 
-  var dweets = document.querySelectorAll(".dweet");
+  var dweets = document.querySelectorAll('.dweet');
   [].forEach.call(dweets, function(dweet) {
     registerOnKeyListener(dweet);
     registerStatsClickListeners(dweet);
   });
-
 
   // Update editor!
   var editor = document.querySelector('#editor');
@@ -67,7 +65,7 @@ window.onload = function() {
   oldCode = editor.value;
   showCode(editoriframe, oldCode);
   editor.addEventListener('keyup', function() {
-    if(editor.value == oldCode) {
+    if (editor.value == oldCode) {
       return;
     }
     editor.size = Math.max(editor.value.length, 1);
@@ -76,53 +74,53 @@ window.onload = function() {
   });
 };
 
-function registerWaypoint(iframe){
-  console.log("Registering " + iframe.src);
+function registerWaypoint(iframe) {
+  console.log('Registering ' + iframe.src);
   var inview = new Waypoint.Inview({
     element: iframe,
-      entered: function(dir) {
-        play(iframe)
-      },
-      exit: function(dir) {
-        var fullscreenElement = (document.fullscreenElement ||
+    entered: function(dir) {
+      play(iframe);
+    },
+    exit: function(dir) {
+      var fullscreenElement = (document.fullscreenElement ||
             document.webkitFullscreenElement ||
             document.mozFullScreenElement);
-        if(fullscreenElement != iframe) {
-          pause(iframe)
-        }
-      },
+      if (fullscreenElement != iframe) {
+        pause(iframe);
+      }
+    },
   });
 }
 
-function play(iframe){
-  dweetwin =  iframe.contentWindow || iframe;
-  dweetwin.postMessage("play","*");
-  console.log("Send play to " + iframe.src);
+function play(iframe) {
+  dweetwin = iframe.contentWindow || iframe;
+  dweetwin.postMessage('play', '*');
+  console.log('Send play to ' + iframe.src);
 }
-function pause(iframe){
-  dweetwin =  iframe.contentWindow || iframe;
-  dweetwin.postMessage("pause","*");
-  console.log("Send pause to " + iframe.src);
+function pause(iframe) {
+  dweetwin = iframe.contentWindow || iframe;
+  dweetwin.postMessage('pause', '*');
+  console.log('Send pause to ' + iframe.src);
 }
 
 function showCode(iframe, code) {
-  dweetwin =  iframe.contentWindow || iframe;
-  dweetwin.postMessage("code "+code,'*');
+  dweetwin = iframe.contentWindow || iframe;
+  dweetwin.postMessage('code ' + code, '*');
 }
 
 function showStats(dweet, iframe) {
-  (iframe.contentWindow || iframe).postMessage("showStats", "*");
+  (iframe.contentWindow || iframe).postMessage('showStats', '*');
   $(dweet).find('.show-stats').hide();
   $(dweet).find('.hide-stats').show();
 }
 
 function hideStats(dweet, iframe) {
-  (iframe.contentWindow || iframe).postMessage("hideStats", "*");
+  (iframe.contentWindow || iframe).postMessage('hideStats', '*');
   $(dweet).find('.show-stats').show();
   $(dweet).find('.hide-stats').hide();
 }
 
-function registerOnKeyListener(dweet){
+function registerOnKeyListener(dweet) {
   var iframe = $(dweet).find('.dweetiframe')[0];
   var editor = $(dweet).find('.code-input')[0];
   var changedDweetMenu = $(dweet).find('.dweet-changed');
@@ -133,13 +131,13 @@ function registerOnKeyListener(dweet){
   editor.addEventListener('keyup', function() {
     showStats(dweet, iframe);
 
-    if(editor.value == originalCode){
+    if (editor.value == originalCode) {
       changedDweetMenu.hide();
-    }else{
+    } else {
       changedDweetMenu.show();
     }
 
-    if(editor.value == oldCode) {
+    if (editor.value == oldCode) {
       return;
     }
     editor.size = Math.max(editor.value.length, 1);

--- a/dwitter/static/js/submit-view.js
+++ b/dwitter/static/js/submit-view.js
@@ -1,40 +1,39 @@
 $('window').ready(function() {
-  //Unfocus when we scroll away
+  // Unfocus when we scroll away
   var wayp = new Waypoint.Inview({
     element: $('#editor'),
-      exited: function(dir) {
-        $('#editor').blur(); 
-      },
+    exited: function(dir) {
+      $('#editor').blur();
+    },
   });
 
   console.log(wayp);
 
-  $('#editor').focusin(function(){
-    $('#submit-preview').show(500, function(){wayp.element.context.refresh()});
+  $('#editor').focusin(function() {
+    $('#submit-preview').show(500, function() {wayp.element.context.refresh();});
     $('#submit-help').show(500);
     $('#click-the-code').hide();
     play($('#preview-iframe')[0]);
   });
 
-  $('#editor').focusout(function(){
+  $('#editor').focusout(function() {
     $('#submit-preview').hide(500);
     $('#submit-help').hide(500);
     $('#click-the-code').show();
     pause($('#preview-iframe')[0]);
   });
 
-
-  function play(iframe){
+  function play(iframe) {
     console.log(iframe);
-    dweetwin =  iframe.contentWindow || iframe;
-    dweetwin.postMessage("play","*");
-    console.log("Send play to " + iframe.src);
+    dweetwin = iframe.contentWindow || iframe;
+    dweetwin.postMessage('play', '*');
+    console.log('Send play to ' + iframe.src);
   }
 
-  function pause(iframe){
+  function pause(iframe) {
     console.log(iframe);
-    dweetwin =  iframe.contentWindow || iframe;
-    dweetwin.postMessage("pause", "*");
-    console.log("Send pause to " + iframe.src);
+    dweetwin = iframe.contentWindow || iframe;
+    dweetwin.postMessage('pause', '*');
+    console.log('Send pause to ' + iframe.src);
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dwitter",
+  "version": "1.0.0",
+  "description": "Social network for short js demos",
+  "scripts": {
+    "lint": "eslint --fix dwitter/static/js/*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lionleaf/dwitter.git"
+  },
+  "author": "Andreas Løve Selvik <andreas.l.selvik@gmail.com>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/lionleaf/dwitter/issues"
+  },
+  "homepage": "https://github.com/lionleaf/dwitter#readme",
+  "devDependencies": {
+    "babel-eslint": "^7.1.1",
+    "eslint": "^3.17.1",
+    "eslint-config-defaults": "^9.0.0"
+  }
+}


### PR DESCRIPTION
This PR partially completes https://github.com/lionleaf/dwitter/issues/187. It uses ESLint to lint Dwitter's JS files.

It may be easier to review this PR by looking at https://github.com/lionleaf/dwitter/pull/195/files?w=1, a diff with whitespace differences suppressed.

I have another PR ready that resolves the following issues:

- There are still over 100 unresolved linting errors. (This PR only fixes the errors that ESLint can fix automatically.)
- JS linting is not added to the `make lint` command, and thus will not run in Travis.