### PR TITLE
correctly initialize stats on Firefox

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -111,11 +111,15 @@
   <canvas id=c></canvas>
   <div class=error-display></div>
   <script>
-    var stats = new Stats();
-    stats.showPanel(0);
-    stats.dom.setAttribute('id', 'stats');
-    document.body.appendChild(stats.dom);
+    function createStats() {
+      var stats = new Stats();
+      stats.showPanel(0);
+      stats.dom.setAttribute('id', 'stats');
+      document.body.appendChild(stats.dom);
+      return stats;
+    }
 
+    var stats = createStats();
     setStatsVisibility({{ newDweet }});
 
     var c = document.querySelector("#c");
@@ -135,6 +139,8 @@
        {{ code | safe }}
       }
     function loop() {
+      stats = stats || createStats();
+
       if (playing){
         requestAnimationFrame(loop);
       }


### PR DESCRIPTION
I found this bug on Firefox 52.0. It seems that Firefox throws an error when trying to render the FPS widget on the hidden new dweet iframe. This change ensures that the FPS widget is rendered correctly.

### Before:

![without-stats-fix](https://cloud.githubusercontent.com/assets/8731922/23977151/d7d3ba1c-09c2-11e7-8c28-17b11f7e8238.gif)

### After:

![with-stats-fix](https://cloud.githubusercontent.com/assets/8731922/23977150/d7d02d16-09c2-11e7-852c-a3ef8373cf27.gif)
