### PR TITLE
refresh Waypoints on comment load or new dweet form slide-down

### DIFF
--- a/dwitter/static/js/ajax-handling.js
+++ b/dwitter/static/js/ajax-handling.js
@@ -49,7 +49,7 @@ var loadComments = function() {
 
   var loadCommentsResponse = function(serverResponse_json, textStatus_ignored,
        jqXHR_ignored) {
-    var $comment_section = $load_comments_button.parents('.comments');
+    var comment_section = $load_comments_button.parents('.comments')[0];
 
     if (serverResponse_json.next) {
       alert('Woops, there are more comments, but they are unloadable as of now. Please bug lionleaf to fix');
@@ -64,7 +64,10 @@ var loadComments = function() {
       }
       new_comment_list += getCommentHTML(comment);
     }
-    $comment_section[0].innerHTML = new_comment_list + $comment_section[0].innerHTML;
+    $(comment_section)
+      .html(new_comment_list + comment_section.innerHTML)
+      .promise()
+      .done(Waypoint.refreshAll);
   };
 
   var config = {

--- a/dwitter/static/js/feed.js
+++ b/dwitter/static/js/feed.js
@@ -57,7 +57,7 @@ $(document).ready(function() {
 
   $('.dweet-create-form-title').click(function() {
     $(this).hide();
-    var dweet = $('.submit-box').slideDown();
+    var dweet = $('.submit-box').slideDown(Waypoint.refreshAll);
     registerOnKeyListener(dweet);
     var iframe = $(dweet).find('.dweetiframe')[0];
     registerWaypoint(iframe);


### PR DESCRIPTION
Closes #194.

With this change, [`Waypoint.refreshAll`](http://imakewebthings.com/waypoints/api/refresh-all/) is called whenever the layout of the page is updated (i.e. whenever comments are loaded or the new dweet form slides down).