### PR TITLE
Make share links right-clickable (permalink)

### DIFF
--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -17,7 +17,7 @@
       <a class="show-stats" href="javascript:;" target="_blank">show FPS</a>
       <a class="hide-stats" href="javascript:;" target="_blank">hide FPS</a>
       <a class=fullscreen-button href="javascript:;" target="_blank">fullscreen</a>
-      <a class=share-button href="{% url %}" target="_blank">share</a>
+      <a class=share-button href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">share</a>
       {% if request.user == dweet.author or request.user.is_staff %}
         <form class="dweet-delete-form" action="{% url 'dweet_delete' dweet_id=dweet.id %}" method="post"
           onsubmit="return confirm('Are you sure you want to delete the dweet (cannot be reversed)?');" >

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -17,7 +17,7 @@
       <a class="show-stats" href="javascript:;" target="_blank">show FPS</a>
       <a class="hide-stats" href="javascript:;" target="_blank">hide FPS</a>
       <a class=fullscreen-button href="javascript:;" target="_blank">fullscreen</a>
-      <a class=share-button href="javascript:;" target="_blank">share</a>
+      <a class=share-button href="{% url %}" target="_blank">share</a>
       {% if request.user == dweet.author or request.user.is_staff %}
         <form class="dweet-delete-form" action="{% url 'dweet_delete' dweet_id=dweet.id %}" method="post"
           onsubmit="return confirm('Are you sure you want to delete the dweet (cannot be reversed)?');" >


### PR DESCRIPTION
I really wanted a "permalink" for dweets I find in the feed.

My primary use-case is to open this dweet in a new tab, e.g. for editing. But it could also be useful to open it in the current window, or to bookmark the dweet in browser bookmarks.

I considered removing the "share" link entirely and replacing it with a link called "permalink" or "link" that would simply be a normal link to the dweet's page. This would allow single-click to open in current window, ctrl-click to open in a tab, and right-click copy to share the link with friends.

If you like that idea, I am happy to implement it! Just let me know.

But what I have actually implemented in this PR is only a small change to what the site has currently:

> I changed the share link's `href` from `javascript:;` to the URL of the dweet.

***Needs testing***: I believe single-click will do exactly what it did before (display the share-link input box), because in both cases where that click is listened for, there is an `evt.preventDefault()` which will stop the browser from following the link.

So what feature does it add? It allows us to right-click on the "share" link and open-in-new-tab. That is what this PR is for!