### PR TITLE
Add a feed page which shows old dweets randomly

### DIFF
--- a/dwitter/feed/urls.py
+++ b/dwitter/feed/urls.py
@@ -23,6 +23,11 @@ urlpatterns = [
     url(r'^new/page/(?P<page_nr>\d+)$',
         views.feed, {'sort': 'new'}, name='new_feed_page'),
 
+    url(r'^old$',
+        views.feed, {'page_nr': 1, 'sort': 'old'}, name='old_feed'),
+    url(r'^old/page/(?P<page_nr>\d+)$',
+        views.feed, {'sort': 'old'}, name='old_feed_page'),
+
     url(r'^d/(?P<dweet_id>\d+)$',
         views.dweet_show, name='dweet_show'),
     url(r'^d/(?P<dweet_id>\d+)/reply$',

--- a/dwitter/feed/urls.py
+++ b/dwitter/feed/urls.py
@@ -23,10 +23,10 @@ urlpatterns = [
     url(r'^new/page/(?P<page_nr>\d+)$',
         views.feed, {'sort': 'new'}, name='new_feed_page'),
 
-    url(r'^old$',
-        views.feed, {'page_nr': 1, 'sort': 'old'}, name='old_feed'),
-    url(r'^old/page/(?P<page_nr>\d+)$',
-        views.feed, {'sort': 'old'}, name='old_feed_page'),
+    url(r'^random$',
+        views.feed, {'page_nr': 1, 'sort': 'random'}, name='random_feed'),
+    url(r'^random/page/(?P<page_nr>\d+)$',
+        views.feed, {'sort': 'random'}, name='random_feed_page'),
 
     url(r'^d/(?P<dweet_id>\d+)$',
         views.dweet_show, name='dweet_show'),

--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -76,6 +76,11 @@ def feed(request, page_nr, sort):
                       .order_by('-hotness', '-posted')[first:last])
         next_url = reverse('hot_feed_page', kwargs={'page_nr': page + 1})
         prev_url = reverse('hot_feed_page', kwargs={'page_nr': page - 1})
+    elif (sort == "old"):
+        dweet_list = (Dweet.objects.annotate(num_likes=Count('likes'))
+                      .order_by('?')[first:last])
+        next_url = reverse('old_feed_page', kwargs={'page_nr': page + 1})
+        prev_url = reverse('old_feed_page', kwargs={'page_nr': page - 1})
     else:
         raise Http404("No such sorting method " + sort)
 

--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -76,11 +76,10 @@ def feed(request, page_nr, sort):
                       .order_by('-hotness', '-posted')[first:last])
         next_url = reverse('hot_feed_page', kwargs={'page_nr': page + 1})
         prev_url = reverse('hot_feed_page', kwargs={'page_nr': page - 1})
-    elif (sort == "old"):
-        dweet_list = (Dweet.objects.annotate(num_likes=Count('likes'))
-                      .order_by('?')[first:last])
-        next_url = reverse('old_feed_page', kwargs={'page_nr': page + 1})
-        prev_url = reverse('old_feed_page', kwargs={'page_nr': page - 1})
+    elif (sort == "random"):
+        dweet_list = Dweet.objects.order_by('?')[first:last]
+        next_url = reverse('random_feed_page', kwargs={'page_nr': page + 1})
+        prev_url = reverse('random_feed_page', kwargs={'page_nr': page - 1})
     else:
         raise Http404("No such sorting method " + sort)
 

--- a/dwitter/templates/feed/feed.html
+++ b/dwitter/templates/feed/feed.html
@@ -31,6 +31,7 @@
   <li><a class="hot" href="{% url 'hot_feed' %}">hot</a></li>
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
   <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
+  <li><a class="old" href="{% url 'old_feed' %}">old</a></li>
   {%elif feed_type == "user" %}
   <li><a class="new" href="{% url 'user_sort_feed' sort='new' url_username=feed_user %}">new</a></li>
   <li><a class="top" href="{% url 'user_sort_feed' sort='top' url_username=feed_user %}">top</a></li>

--- a/dwitter/templates/feed/feed.html
+++ b/dwitter/templates/feed/feed.html
@@ -31,7 +31,7 @@
   <li><a class="hot" href="{% url 'hot_feed' %}">hot</a></li>
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
   <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
-  <li><a class="old" href="{% url 'old_feed' %}">old</a></li>
+  <li><a class="random" href="{% url 'random_feed' %}">random</a></li>
   {%elif feed_type == "user" %}
   <li><a class="new" href="{% url 'user_sort_feed' sort='new' url_username=feed_user %}">new</a></li>
   <li><a class="top" href="{% url 'user_sort_feed' sort='top' url_username=feed_user %}">top</a></li>

--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -26,7 +26,7 @@
   <li><a class="hot" href="{% url 'hot_feed' %}">hot</a></li>
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
   <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
-  <li><a class="old" href="{% url 'old_feed' %}">old</a></li>
+  <li><a class="random" href="{% url 'random_feed' %}">random</a></li>
 </ul>
 {% endblock %}
 

--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -26,6 +26,7 @@
   <li><a class="hot" href="{% url 'hot_feed' %}">hot</a></li>
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
   <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
+  <li><a class="old" href="{% url 'old_feed' %}">old</a></li>
 </ul>
 {% endblock %}
 

--- a/dwitter/user/urls.py
+++ b/dwitter/user/urls.py
@@ -4,17 +4,17 @@ from . import views
 urlpatterns = [
     url(r'^(?P<url_username>[\w.@+-]+)$',
         views.user_feed, {'page_nr': '1', 'sort': 'new'}, name='user_feed'),
-    url(r'^(?P<url_username>[\w.@+-]+)/(?P<sort>hot|new|top|old)$',
+    url(r'^(?P<url_username>[\w.@+-]+)/(?P<sort>hot|new|top|random)$',
         views.user_feed, {'page_nr': '1'}, name='user_sort_feed'),
     url(r'^(?P<url_username>[\w.@+-]+)/'
-        '(?P<sort>hot|new|top|old)/(?P<page_nr>\d+)$',
+        '(?P<sort>hot|new|top|random)/(?P<page_nr>\d+)$',
         views.user_feed, name='user_feed_page'),
     url(r'^(?P<url_username>[\w.@+-]+)/awesome$',
         views.user_liked, {'page_nr': '1', 'sort': 'new'}, name='user_liked'),
-    url(r'^(?P<url_username>[\w.@+-]+)/awesome/(?P<sort>hot|new|top|old)$',
+    url(r'^(?P<url_username>[\w.@+-]+)/awesome/(?P<sort>hot|new|top|random)$',
         views.user_liked, {'page_nr': '1'}, name='user_sort_liked'),
     url(r'^(?P<url_username>[\w.@+-]+)/'
-        '(?P<sort>hot|new|top|old)/awesome/(?P<page_nr>\d+)$',
+        '(?P<sort>hot|new|top|random)/awesome/(?P<page_nr>\d+)$',
         views.user_liked, name='user_liked_page'),
     url(r'^(?P<url_username>[\w.@+-]+)/settings$',
         views.user_settings, name='user_settings'),

--- a/dwitter/user/urls.py
+++ b/dwitter/user/urls.py
@@ -4,17 +4,17 @@ from . import views
 urlpatterns = [
     url(r'^(?P<url_username>[\w.@+-]+)$',
         views.user_feed, {'page_nr': '1', 'sort': 'new'}, name='user_feed'),
-    url(r'^(?P<url_username>[\w.@+-]+)/(?P<sort>hot|new|top)$',
+    url(r'^(?P<url_username>[\w.@+-]+)/(?P<sort>hot|new|top|old)$',
         views.user_feed, {'page_nr': '1'}, name='user_sort_feed'),
     url(r'^(?P<url_username>[\w.@+-]+)/'
-        '(?P<sort>hot|new|top)/(?P<page_nr>\d+)$',
+        '(?P<sort>hot|new|top|old)/(?P<page_nr>\d+)$',
         views.user_feed, name='user_feed_page'),
     url(r'^(?P<url_username>[\w.@+-]+)/awesome$',
         views.user_liked, {'page_nr': '1', 'sort': 'new'}, name='user_liked'),
-    url(r'^(?P<url_username>[\w.@+-]+)/awesome/(?P<sort>hot|new|top)$',
+    url(r'^(?P<url_username>[\w.@+-]+)/awesome/(?P<sort>hot|new|top|old)$',
         views.user_liked, {'page_nr': '1'}, name='user_sort_liked'),
     url(r'^(?P<url_username>[\w.@+-]+)/'
-        '(?P<sort>hot|new|top)/awesome/(?P<page_nr>\d+)$',
+        '(?P<sort>hot|new|top|old)/awesome/(?P<page_nr>\d+)$',
         views.user_liked, name='user_liked_page'),
     url(r'^(?P<url_username>[\w.@+-]+)/settings$',
         views.user_settings, name='user_settings'),

--- a/dwitter/user/views.py
+++ b/dwitter/user/views.py
@@ -57,9 +57,8 @@ def user_feed(request, url_username, page_nr, sort, dweets=None, url=None):
     elif (sort == "hot"):
         dweet_list = (dweet_list.annotate(num_likes=Count('likes'))
                       .order_by('-num_likes')[first:last])
-    elif (sort == "old"):
-        dweet_list = (dweet_list.annotate(num_likes=Count('likes'))
-                      .order_by('?')[first:last])
+    elif (sort == "random"):
+        dweet_list = dweet_list.order_by('?')[first:last]
     else:
         raise Http404("No such sorting method " + sort)
 

--- a/dwitter/user/views.py
+++ b/dwitter/user/views.py
@@ -57,6 +57,9 @@ def user_feed(request, url_username, page_nr, sort, dweets=None, url=None):
     elif (sort == "hot"):
         dweet_list = (dweet_list.annotate(num_likes=Count('likes'))
                       .order_by('-num_likes')[first:last])
+    elif (sort == "old"):
+        dweet_list = (dweet_list.annotate(num_likes=Count('likes'))
+                      .order_by('?')[first:last])
     else:
         raise Http404("No such sorting method " + sort)
 


### PR DESCRIPTION
Rather than just filing issues, I thought I might try and help out. So here is the "random" feed suggested in #210 .

In this PR I have called it "old", but that could change if you prefer "random".

I used Django's `.order_by('?')`. Because this is not a true shuffle, it carries a small risk of showing the same dweet twice in the feed (inversely proportional to the number of tweets in the system).

I think that is an acceptable payoff, because any approach that performs a true shuffle will also add complexity: either a new field in the DB (which must be updated occasionally) or some kind of temporary state. Better to KISS. Seeing a dweet twice would be a rare occurrence and even then the discomfort felt by the user would be quite small.

I kept the code in line with the other feeds simply for consistency. In fact the page we are on won't make any difference to the results.

I did not provide an "old" feed for user pages, but I add some code for it here and there, in case we want to add that feature in future.

***Needs testing***. Sorry I did not get the environment set up here today. Fortunately the changes I made look pretty simple. But for today at least, I will have to leave it to someone else to check things work as expected.