### PR TITLE
Fix last eslint warning and treat warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ lint-python:
 
 .PHONY: lint-js
 lint-js:
-	npm run lint
+	npm run lint -- --max-warnings 0
 
 .PHONY: lint-js-fix
 lint-js-fix:
-	npm run lint-fix
+	npm run lint-fix -- --max-warnings 0
 
 .PHONY: test
 test:

--- a/dwitter/static/js/ajax-handling.js
+++ b/dwitter/static/js/ajax-handling.js
@@ -52,10 +52,7 @@ function loadComments() {
       return stickyTop && index === 0 ? '' : getCommentHTML(comment);
     }).join('');
 
-    if (response.next) {
-      alert('Woops, there are more comments, but they are unloadable as of now. ' +
-            'Please bug lionleaf to fix');
-    } else {
+    if (!response.next) {
       $loadCommentsButton.parents('.comment').hide();
     }
 


### PR DESCRIPTION
Is it too much to fail on eslint warnings? Open to a discussion on that point. I'll rebase off the last commit in that case.