### PR TITLE
Add CSS for random link when selected (previously overlooked)

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -512,6 +512,9 @@ body.top .top-sort-list a.top {
 body.hot .top-sort-list a.hot {
   font-weight: bold;
 }
+body.random .top-sort-list a.random {
+  font-weight: bold;
+}
 
 #submit-preview {
 }


### PR DESCRIPTION
Fixes a minor oversight in my previous PR.

Currently when on the random page, the "random" link is not made bold.