### PR TITLE
Fix CSS wrapping issue on mobile of code block

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -238,6 +238,8 @@ input.comment-submit:active {
 
 .author-remix-wrapper{
   padding: 10px 0;
+  display: inline-block;
+  width: 100%;
 }
 
 .dweet-author {
@@ -569,7 +571,7 @@ body.random .top-sort-list a.random {
 }
 
 .dark-section {
-  margin: 20px -15px -15px;
+  margin: 10px -15px -15px;
   background: #222;
   padding: 15px;
   overflow: hidden;


### PR DESCRIPTION
When remix text + username got too long for screen it would overflow and
squish the code block. This fixes that issue by playing with the dark
magic that is CSS flow rules. @sigvef / @stianjensen / CSS ninjas out there: I played around with the CSS until it worked, is there anything fundamentally flawed with this technique?

Before:
<img width="384" alt="screenshot 2017-09-24 00 37 03" src="https://user-images.githubusercontent.com/610925/30778026-a74753f4-a0c1-11e7-837b-eaec0fdf1850.png">

After:
<img width="375" alt="screenshot 2017-09-24 00 37 37" src="https://user-images.githubusercontent.com/610925/30778027-acb06178-a0c1-11e7-8c4f-8eb65bbb59fa.png">
