### PR TITLE
CSS tweaks to fix overflow issues in header on mobile screens

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -213,7 +213,7 @@ input.comment-submit:active {
   color: white;
   font-size: 1.1em;
   cursor: pointer;
-  width: 50%;
+  width: 200px;
   font-weight: bold;
   text-align: center;
   padding: 10px;

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -4,6 +4,12 @@
   padding:0px;
 }
 
+.clear-fix:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
 .avatar {
   width: 36px;
   height: 36px;
@@ -290,11 +296,10 @@ iframe {
 .head-menu {
   width:100%;
   background:white;
-  text-align:center;
+  text-align:left;
   border-bottom:1px solid #ddd;
   box-shadow:0px 0px 2px rgba(0,0,0,0.051);
   padding: 1em 0;
-  height: 40px;
   line-height: 40px;
 }
 
@@ -302,6 +307,7 @@ iframe {
   position: relative;
   max-width: 960px;
   margin: 0 auto;
+  padding-left: 1em;
 }
 
 .next-page {
@@ -378,8 +384,9 @@ iframe {
 }
 
 .header-title {
-  margin: 0 1em;
-  float: left;
+  margin-right: 1em;
+  padding-left: 15px;
+  display: inline-block;
 }
 
 .footer {
@@ -496,7 +503,7 @@ form.like {
 .top-sort-list {
   list-style-type:none;
   padding:0;
-  float: left;
+  display: inline-block;
 }
 .top-sort-list li {
   display: inline-block;

--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -30,14 +30,13 @@
     {% endblock %}
   </head>
   <body class="{% block body_class %}{% endblock %}">
-    <div class=head-menu>
+    <div class="head-menu clear-fix">
       <div class=head-menu-inner>
         <h2 class=header-title>
           <a href="{% url 'root' %}">Dwitter</a>
           {% block header_title %}{% endblock %}
         </h2>
 
-        {% block top-nav %}{% endblock %}
 
         <div class="head-account-info {% if request.user.is_authenticated %} is-logged-in {% endif %}">
           {% if request.user.is_authenticated %}
@@ -57,6 +56,9 @@
           <a href="{% url 'register'  %}" > register </a>
           {% endif %}
         </div>
+
+        {% block top-nav %}{% endblock %}
+
       </div>
     </div>
     <div id=content>


### PR DESCRIPTION
**Before**:

<img width="594" alt="screenshot 2017-09-24 16 27 38" src="https://user-images.githubusercontent.com/610925/30784054-809237b8-a145-11e7-984d-74012c03c179.png">

<img width="386" alt="screenshot 2017-09-24 16 27 47" src="https://user-images.githubusercontent.com/610925/30784055-845ef476-a145-11e7-8b16-abd97fcc0859.png">


**After**:

<img width="629" alt="screenshot 2017-09-24 16 28 10" src="https://user-images.githubusercontent.com/610925/30784060-8cdba806-a145-11e7-8bef-7c6a146468fb.png">

<img width="381" alt="screenshot 2017-09-24 16 27 57" src="https://user-images.githubusercontent.com/610925/30784056-894da720-a145-11e7-9d65-fcbbe2ad268f.png">