### PR TITLE
Fix url regex that allowed illegal url

### DIFF
--- a/dwitter/dweet/urls.py
+++ b/dwitter/dweet/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^id/(?P<dweet_id>[0-9]*)$', views.fullscreen_dweet,
+    url(r'^id/(?P<dweet_id>[0-9]+)$', views.fullscreen_dweet,
         name='fullscreen_dweet'),
     url(r'^blank$', views.blank_dweet, name='blank_dweet'),
 ]


### PR DESCRIPTION
Old url pattern allowed /id/  (without a number), which resulted in a
500 (and an email). And lately google spiders seems to do this daily.