### PR TITLE
Make Dwitter header fixed, move 'new dweet' button

### DIFF
--- a/dwitter/static/js/feed.js
+++ b/dwitter/static/js/feed.js
@@ -68,7 +68,6 @@ $(document).ready(function() {
     registerWaypoint(iframe);
     /* eslint-enable no-undef */
 
-    $(this).hide();
     $(dweet).find('textarea').focus();
   });
 });

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -115,7 +115,7 @@ ul.messages {
 }
 
 #content {
-  padding: 0 0 1em;
+  padding: 50px 0 1em;
   margin: 0 auto;
 }
 
@@ -141,7 +141,7 @@ ul.messages {
 .dweet-feed {
   max-width: 600px;
   margin: 0 auto;
-  padding: 15px;
+  padding: 0 15px;
 }
 
 .dweet, .card, .loading, .end-of-feed {
@@ -219,13 +219,14 @@ input.comment-submit:active {
   color: white;
   font-size: 1.1em;
   cursor: pointer;
-  width: 200px;
   font-weight: bold;
   text-align: center;
   padding: 10px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
   border-radius: 5px;
-  margin: 0 auto;
+  height: 20px;
+  line-height: 20px;
+  float: right;
 }
 
 .dweet-create-form-title:hover {
@@ -236,8 +237,8 @@ input.comment-submit:active {
   background: white;
   color: #4599ca;
   border-radius: 50%;
-  width: 27px;
-  height: 27px;
+  width: 20px;
+  height: 20px;
   display: inline-block;
   margin-right: 10px;
 }
@@ -294,12 +295,14 @@ iframe {
 }
 
 .head-menu {
+  position: fixed;
+  z-index: 100;
   width:100%;
   background:white;
   text-align:left;
   border-bottom:1px solid #ddd;
   box-shadow:0px 0px 2px rgba(0,0,0,0.051);
-  padding: 1em 0;
+  padding: 5px 0;
   line-height: 40px;
 }
 
@@ -314,10 +317,9 @@ iframe {
   display:none;
 }
 .head-account-info {
-  margin-right: 1em;
+  margin: 0 1em;
   float: right;
   text-align: right;
-  width: 160px;
 }
 
 .head-account-info .avatar {
@@ -327,7 +329,6 @@ iframe {
 .head-account-info .name {
   text-overflow: ellipsis;
   overflow: hidden;
-  width: 105px;
   display: inline-block;
   vertical-align: middle;
 }
@@ -340,6 +341,18 @@ iframe {
     margin: 0;
   }
   .head-account-info .name {
+    display: none;
+  }
+}
+
+@media (max-width: 660px) {
+  #content {
+    padding-top: 90px;
+  }
+}
+
+@media (max-width: 350px) {
+  .dweet-create-form-title-label span {
     display: none;
   }
 }

--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -37,7 +37,6 @@
           {% block header_title %}{% endblock %}
         </h2>
 
-
         <div class="head-account-info {% if request.user.is_authenticated %} is-logged-in {% endif %}">
           {% if request.user.is_authenticated %}
 
@@ -56,6 +55,13 @@
           <a href="{% url 'register'  %}" > register </a>
           {% endif %}
         </div>
+
+        {% if show_submit_box %}
+        <div class="dweet-create-form-title">
+          <span class="add-icon">+</span>
+          <span class="dweet-create-form-title-label">New <span>dweet</span></span>
+        </div>
+        {% endif %}
 
         {% block top-nav %}{% endblock %}
 

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -1,5 +1,4 @@
 {% load subdomainurls %}
-<div class="dweet-create-form-title"><span class="add-icon">+</span>Create new dweet</div>
 <div class="dweet submit-box">
   <div
     class=canvas-iframe-container-wrapper


### PR DESCRIPTION
I tried looking at tweaking the Dwitter header to make the buttons in the header always accessible even when you've scrolled miles down the page. To make this work I decided to reduce the height of the header somewhat to make it not take up not much permanent vertical space.

I also moved the 'New dweet' button into the header, so you don't have to scroll all the way up to find it.

If I didn't mess up, this should also work pretty well on mobile.

Screenshots:
<img width="1238" alt="screen shot 2017-10-30 at 19 38 19" src="https://user-images.githubusercontent.com/1413267/32189287-a5b31e00-bdaa-11e7-8a65-4611a0fdad6a.png">
<img width="1238" alt="screen shot 2017-10-30 at 19 38 16" src="https://user-images.githubusercontent.com/1413267/32189294-aae8729e-bdaa-11e7-8a30-26718a611e3b.png">
<img width="512" alt="screen shot 2017-10-30 at 19 38 02" src="https://user-images.githubusercontent.com/1413267/32189305-af0a3f42-bdaa-11e7-894b-2ad35e113646.png">
