### PR TITLE
Add serve target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ all: update migrate
 run:
 	python manage.py runserver
 
+.PHONY: serve
+serve:
+	python manage.py runserver 0.0.0.0:8000
+
 .PHONY: update
 update:
 	pip install --upgrade -r requirements.txt


### PR DESCRIPTION
This binds the development server to 0.0.0.0, allowing connections from
external devices. It is particularly useful for e.g. testing on mobile,
and for developers with a Virtualbox setup akin to the one I'm using.