### PR TITLE
Old style exception to new style for Python 3

### DIFF
--- a/dwitter/settings/__init__.py
+++ b/dwitter/settings/__init__.py
@@ -3,5 +3,5 @@ from dwitter.settings.base import *
 
 try:
       from dwitter.settings.local import *
-except ImportError, e:
+except ImportError:
         raise ImportError("Failed to import local settings")


### PR DESCRIPTION
flake8 testing of https://github.com/lionleaf/dwitter on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./dwitter/settings/__init__.py:6:19: E999 SyntaxError: invalid syntax
except ImportError, e:
                  ^
```