### PR TITLE
insert_magic_links filter for dweet and user links

### DIFF
--- a/dwitter/serializers.py
+++ b/dwitter/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from dwitter.models import Dweet, Comment
+from dwitter.templatetags.insert_magic_links import insert_magic_links
 from django.contrib.auth.models import User
 from django.template.defaultfilters import urlizetrunc
 
@@ -20,7 +21,7 @@ class CommentSerializer(serializers.ModelSerializer):
         fields = ('urlized_text', 'text', 'posted', 'reply_to', 'author')
 
     def get_urlized_text(self, obj):
-        return urlizetrunc(obj.text, 45)
+        return insert_magic_links(urlizetrunc(obj.text, 45))
 
 
 class DweetSerializer(serializers.ModelSerializer):

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -1,5 +1,6 @@
 {% load subdomainurls %}
 {% load to_gravatar_url %}
+{% load insert_magic_links %}
 <div class=dweet-wrapper>
   <div class=dweet >
     <div class=canvas-iframe-container-wrapper>
@@ -77,7 +78,7 @@
     <ul class=sticky-comments>
       <li class="comment sticky-comment">
         <a class="comment-name sticky-comment" href="{% url 'user_feed' url_username=dweet.comments.last.author.username %}">{{ dweet.comments.last.author.username }}:</a>
-        <span class="comment-message sticky-comment">{{ dweet.comments.last.text | urlizetrunc:45 }}</span>
+        <span class="comment-message sticky-comment">{{ dweet.comments.last.text | urlizetrunc:45 | insert_magic_links }}</span>
       </li>
       </ul>
         {% endif %}
@@ -97,7 +98,7 @@
       {% if comment != dweet.comments.last or dweet.comments.last.author != dweet.author  %}
       <li class=comment>
       <a class=comment-name href="{% url 'user_feed' url_username=comment.author.username %}">{{ comment.author.username }}:</a>
-      <span class="comment-message">{{ comment.text | urlizetrunc:45 }}</span>
+      <span class="comment-message">{{ comment.text | urlizetrunc:45 | insert_magic_links }}</span>
       </li>
       {% endif %}
       {% endfor %}

--- a/dwitter/templatetags/insert_magic_links.py
+++ b/dwitter/templatetags/insert_magic_links.py
@@ -17,6 +17,15 @@ def to_link(m):
 
     return '<a href="%s">%s</a>' % (path, text)
 
+
 @register.filter(is_safe=True)
 def insert_magic_links(text):
-    return re.sub(r'(?:^|(?<=\s))(?P<text>/d/(?P<dweet_id>\d+)|/u/(?P<username>[\w.@+-]+))(?=$|\s)', to_link, text)
+    return re.sub(
+        r'(?:^|(?<=\s))'                # start of string or whitespace
+        r'(?P<text>'                    # capture original pattern
+        r'/d/(?P<dweet_id>\d+)'         # dweet reference
+        r'|'                            # or
+        r'/u/(?P<username>[\w.@+-]+))'  # user reference
+        r'(?=$|\s)',                    # end of string or whitespace
+        to_link,
+        text)

--- a/dwitter/templatetags/insert_magic_links.py
+++ b/dwitter/templatetags/insert_magic_links.py
@@ -1,0 +1,21 @@
+import re
+from django import template
+from django.core.urlresolvers import reverse
+
+register = template.Library()
+
+
+def to_link(match):
+    dweet_id = match.group(1)
+    username = match.group(2)
+
+    if username is None:
+        path = reverse('dweet_show', kwargs={'dweet_id': dweet_id})
+    else:
+        path = reverse('user_feed', kwargs={'url_username': username})
+
+    return '<a href="%s">%s</a>' % (path, match.group(0))
+
+@register.filter(is_safe=True)
+def insert_magic_links(text):
+    return re.sub(r'/d/(\d+)|/u/([\w.@+-]+)', to_link, text)

--- a/dwitter/templatetags/insert_magic_links.py
+++ b/dwitter/templatetags/insert_magic_links.py
@@ -28,4 +28,5 @@ def insert_magic_links(text):
         r'/u/(?P<username>[\w.@+-]+))'  # user reference
         r'(?=$|\s)',                    # end of string or whitespace
         to_link,
-        text)
+        text
+    )

--- a/dwitter/templatetags/insert_magic_links.py
+++ b/dwitter/templatetags/insert_magic_links.py
@@ -5,17 +5,18 @@ from django.core.urlresolvers import reverse
 register = template.Library()
 
 
-def to_link(match):
-    dweet_id = match.group(1)
-    username = match.group(2)
+def to_link(m):
+    text = m.group('text')
+    dweet_id = m.group('dweet_id')
+    username = m.group('username')
 
     if username is None:
         path = reverse('dweet_show', kwargs={'dweet_id': dweet_id})
     else:
         path = reverse('user_feed', kwargs={'url_username': username})
 
-    return '<a href="%s">%s</a>' % (path, match.group(0))
+    return '<a href="%s">%s</a>' % (path, text)
 
 @register.filter(is_safe=True)
 def insert_magic_links(text):
-    return re.sub(r'/d/(\d+)|/u/([\w.@+-]+)', to_link, text)
+    return re.sub(r'(?:^|(?<=\s))(?P<text>/d/(?P<dweet_id>\d+)|/u/(?P<username>[\w.@+-]+))(?=$|\s)', to_link, text)

--- a/dwitter/tests/templatetags/test_insert_magic_links.py
+++ b/dwitter/tests/templatetags/test_insert_magic_links.py
@@ -23,38 +23,38 @@ class DweetTestCase(TestCase):
 
     def test_insert_magic_links_replaces_standalone_user(self):
         self.assertEqual(
-            '<a href="/u/username">/u/username</a>',
-            insert_magic_links('/u/username')
+            '<a href="/u/a">/u/a</a>',
+            insert_magic_links('/u/a')
         )
 
     def test_insert_magic_links_replaces_user_at_start_of_string(self):
         self.assertEqual(
-            '<a href="/u/username">/u/username</a> suffix',
-            insert_magic_links('/u/username suffix')
+            '<a href="/u/a">/u/a</a> suffix',
+            insert_magic_links('/u/a suffix')
         )
 
     def test_insert_magic_links_replaces_user_at_end_of_string(self):
         self.assertEqual(
-            'prefix <a href="/u/username">/u/username</a>',
-            insert_magic_links('prefix /u/username')
+            'prefix <a href="/u/a">/u/a</a>',
+            insert_magic_links('prefix /u/a')
         )
 
     def test_insert_magic_links_replaces_user_at_middle_of_string(self):
         self.assertEqual(
-            'prefix <a href="/u/username">/u/username</a> suffix',
-            insert_magic_links('prefix /u/username suffix')
+            'prefix <a href="/u/a">/u/a</a> suffix',
+            insert_magic_links('prefix /u/a suffix')
         )
 
     def test_insert_magic_links_bypasses_user_prefixed_by_non_space(self):
         self.assertEqual(
-            'prefix/u/username suffix',
-            insert_magic_links('prefix/u/username suffix')
+            'prefix/u/a suffix',
+            insert_magic_links('prefix/u/a suffix')
         )
 
     def test_insert_magic_links_bypasses_user_suffixed_by_non_space(self):
         self.assertEqual(
-            'prefix /u/username/suffix',
-            insert_magic_links('prefix /u/username/suffix')
+            'prefix /u/a/suffix',
+            insert_magic_links('prefix /u/a/suffix')
         )
 
     def test_insert_magic_links_replaces_dweet_with_valid_characters(self):

--- a/dwitter/tests/templatetags/test_insert_magic_links.py
+++ b/dwitter/tests/templatetags/test_insert_magic_links.py
@@ -9,6 +9,24 @@ class DweetTestCase(TestCase):
             insert_magic_links('prefix <h1>content</h1> suffix')
         )
 
+    def test_insert_magic_links_replaces_user_with_valid_characters(self):
+        self.assertEqual(
+            '<a href="/u/a1_.@+-">/u/a1_.@+-</a>',
+            insert_magic_links('/u/a1_.@+-')
+        )
+
+    def test_insert_magic_links_bypasses_user_with_invalid_characters(self):
+        self.assertEqual(
+            '/u/a1$',
+            '/u/a1$'
+        )
+
+    def test_insert_magic_links_replaces_standalone_user(self):
+        self.assertEqual(
+            '<a href="/u/username">/u/username</a>',
+            insert_magic_links('/u/username')
+        )
+
     def test_insert_magic_links_replaces_user_at_start_of_string(self):
         self.assertEqual(
             '<a href="/u/username">/u/username</a> suffix',
@@ -39,6 +57,24 @@ class DweetTestCase(TestCase):
             insert_magic_links('prefix /u/username/suffix')
         )
 
+    def test_insert_magic_links_replaces_dweet_with_valid_characters(self):
+        self.assertEqual(
+            '<a href="/d/1234567890">/d/1234567890</a>',
+            insert_magic_links('/d/1234567890')
+        )
+
+    def test_insert_magic_links_bypasses_dweet_with_invalid_characters(self):
+        self.assertEqual(
+            '/d/1a',
+            '/d/1a'
+        )
+
+    def test_insert_magic_links_replaces_standalone_dweet(self):
+        self.assertEqual(
+            '<a href="/d/1">/d/1</a>',
+            insert_magic_links('/d/1')
+        )
+
     def test_insert_magic_links_replaces_dweet_at_start_of_string(self):
         self.assertEqual(
             '<a href="/d/1">/d/1</a> suffix',
@@ -67,4 +103,12 @@ class DweetTestCase(TestCase):
         self.assertEqual(
             'prefix /d/1/suffix',
             insert_magic_links('prefix /d/1/suffix')
+        )
+
+    def test_insert_magic_links_mixed(self):
+        self.assertEqual(
+            '<a href="/u/john">/u/john</a> remixed '
+            '<a href="/d/123">/d/123</a> by '
+            '<a href="/u/jane">/u/jane</a>',
+            insert_magic_links('/u/john remixed /d/123 by /u/jane')
         )

--- a/dwitter/tests/templatetags/test_insert_magic_links.py
+++ b/dwitter/tests/templatetags/test_insert_magic_links.py
@@ -4,34 +4,67 @@ from dwitter.templatetags.insert_magic_links import insert_magic_links
 
 class DweetTestCase(TestCase):
     def test_insert_magic_links_bypasses_html(self):
-        self.assertEqual('prefix <h1>content</h1> suffix', insert_magic_links('prefix <h1>content</h1> suffix'))
+        self.assertEqual(
+            'prefix <h1>content</h1> suffix',
+            insert_magic_links('prefix <h1>content</h1> suffix')
+        )
 
     def test_insert_magic_links_replaces_user_at_start_of_string(self):
-        self.assertEqual('<a href="/u/username">/u/username</a> suffix', insert_magic_links('/u/username suffix'))
+        self.assertEqual(
+            '<a href="/u/username">/u/username</a> suffix',
+            insert_magic_links('/u/username suffix')
+        )
 
     def test_insert_magic_links_replaces_user_at_end_of_string(self):
-        self.assertEqual('prefix <a href="/u/username">/u/username</a>', insert_magic_links('prefix /u/username'))
+        self.assertEqual(
+            'prefix <a href="/u/username">/u/username</a>',
+            insert_magic_links('prefix /u/username')
+        )
 
     def test_insert_magic_links_replaces_user_at_middle_of_string(self):
-        self.assertEqual('prefix <a href="/u/username">/u/username</a> suffix', insert_magic_links('prefix /u/username suffix'))
+        self.assertEqual(
+            'prefix <a href="/u/username">/u/username</a> suffix',
+            insert_magic_links('prefix /u/username suffix')
+        )
 
-    def test_insert_magic_links_bypasses_user_prefixed_by_non_whitespace(self):
-        self.assertEqual('prefix/u/username suffix', insert_magic_links('prefix/u/username suffix'))
+    def test_insert_magic_links_bypasses_user_prefixed_by_non_space(self):
+        self.assertEqual(
+            'prefix/u/username suffix',
+            insert_magic_links('prefix/u/username suffix')
+        )
 
-    def test_insert_magic_links_bypasses_user_suffixed_by_non_whitespace(self):
-        self.assertEqual('prefix /u/username/suffix', insert_magic_links('prefix /u/username/suffix'))
+    def test_insert_magic_links_bypasses_user_suffixed_by_non_space(self):
+        self.assertEqual(
+            'prefix /u/username/suffix',
+            insert_magic_links('prefix /u/username/suffix')
+        )
 
     def test_insert_magic_links_replaces_dweet_at_start_of_string(self):
-        self.assertEqual('<a href="/d/1">/d/1</a> suffix', insert_magic_links('/d/1 suffix'))
+        self.assertEqual(
+            '<a href="/d/1">/d/1</a> suffix',
+            insert_magic_links('/d/1 suffix')
+        )
 
     def test_insert_magic_links_replaces_dweet_at_end_of_string(self):
-        self.assertEqual('prefix <a href="/d/1">/d/1</a>', insert_magic_links('prefix /d/1'))
+        self.assertEqual(
+            'prefix <a href="/d/1">/d/1</a>',
+            insert_magic_links('prefix /d/1')
+        )
 
     def test_insert_magic_links_replaces_dweet_at_middle_of_string(self):
-        self.assertEqual('prefix <a href="/d/1">/d/1</a> suffix', insert_magic_links('prefix /d/1 suffix'))
+        self.assertEqual(
+            'prefix <a href="/d/1">/d/1</a> suffix',
+            insert_magic_links('prefix /d/1 suffix')
+        )
 
-    def test_insert_magic_links_bypasses_dweet_prefixed_by_non_whitespace(self):
-        self.assertEqual('prefix/d/1 suffix', insert_magic_links('prefix/d/1 suffix'))
+    def test_insert_magic_links_bypasses_dweet_prefixed_by_non_space(self):
+        self.assertEqual(
+            'prefix/d/1 suffix',
+            insert_magic_links('prefix/d/1 suffix')
+        )
 
-    def test_insert_magic_links_bypasses_dweet_suffixed_by_non_whitespace(self):
-        self.assertEqual('prefix /d/1/suffix', insert_magic_links('prefix /d/1/suffix'))
+    def test_insert_magic_links_bypasses_dweet_suffixed_by_non_space(self):
+        self.assertEqual(
+            'prefix /d/1/suffix',
+            insert_magic_links('prefix /d/1/suffix')
+        )

--- a/dwitter/tests/templatetags/test_insert_magic_links.py
+++ b/dwitter/tests/templatetags/test_insert_magic_links.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+from dwitter.templatetags.insert_magic_links import insert_magic_links
+
+
+class DweetTestCase(TestCase):
+    def test_insert_magic_links_bypasses_html(self):
+        self.assertEqual('prefix <h1>content</h1> suffix', insert_magic_links('prefix <h1>content</h1> suffix'))
+
+    def test_insert_magic_links_replaces_user_at_start_of_string(self):
+        self.assertEqual('<a href="/u/username">/u/username</a> suffix', insert_magic_links('/u/username suffix'))
+
+    def test_insert_magic_links_replaces_user_at_end_of_string(self):
+        self.assertEqual('prefix <a href="/u/username">/u/username</a>', insert_magic_links('prefix /u/username'))
+
+    def test_insert_magic_links_replaces_user_at_middle_of_string(self):
+        self.assertEqual('prefix <a href="/u/username">/u/username</a> suffix', insert_magic_links('prefix /u/username suffix'))
+
+    def test_insert_magic_links_bypasses_user_prefixed_by_non_whitespace(self):
+        self.assertEqual('prefix/u/username suffix', insert_magic_links('prefix/u/username suffix'))
+
+    def test_insert_magic_links_bypasses_user_suffixed_by_non_whitespace(self):
+        self.assertEqual('prefix /u/username/suffix', insert_magic_links('prefix /u/username/suffix'))
+
+    def test_insert_magic_links_replaces_dweet_at_start_of_string(self):
+        self.assertEqual('<a href="/d/1">/d/1</a> suffix', insert_magic_links('/d/1 suffix'))
+
+    def test_insert_magic_links_replaces_dweet_at_end_of_string(self):
+        self.assertEqual('prefix <a href="/d/1">/d/1</a>', insert_magic_links('prefix /d/1'))
+
+    def test_insert_magic_links_replaces_dweet_at_middle_of_string(self):
+        self.assertEqual('prefix <a href="/d/1">/d/1</a> suffix', insert_magic_links('prefix /d/1 suffix'))
+
+    def test_insert_magic_links_bypasses_dweet_prefixed_by_non_whitespace(self):
+        self.assertEqual('prefix/d/1 suffix', insert_magic_links('prefix/d/1 suffix'))
+
+    def test_insert_magic_links_bypasses_dweet_suffixed_by_non_whitespace(self):
+        self.assertEqual('prefix /d/1/suffix', insert_magic_links('prefix /d/1/suffix'))


### PR DESCRIPTION
Resolves #244 by introducing a new template filter. This could have been also done as a template tag, but I followed to_gravatar_url (which is a filter inside the templatetags folder) as an example.

Potential improvements:
* [x] Make the regexp more specific to ignore cases where the patterns appear in the middle of a URL etc.