### PR TITLE
Default dweet + editor tweaks

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -617,6 +617,7 @@ body.random .top-sort-list a.random {
   outline: 0;
   font-size: small;
   padding: 0;
+  padding-left: 1em;
 }
 
 .dark-section .dweet-code textarea:focus {

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -16,22 +16,22 @@
     <a class="hide-stats visible" href="javascript:;" target="_blank">hide FPS</a>
   </div>
   <div class="dark-section">
-    <code class="function-wrap">function u(t){</code>
+    <code class="function-wrap">function u(t) {</code>
     <form action="{% url 'dweet' %}" method="post">
       {% csrf_token %}
       <div class=dweet-code>
         <textarea
           autocorrect="off" autocapitalize="off" spellcheck="false"
-          name=code
-          class=code-input
-          rows=4
-          id=editor
+          name="code"
+          class="code-input"
+          rows="4"
+          id="editor"
           oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';"
-          >c.width=1920; /* clear the canvas */
-  for(i=0;i<9;i++)
-  x.fillRect(400+i*100+S(t)*300, 400, 50, 200) /* draw 50x200 rects */</textarea>
+          >c.width=1920 // clear the canvas
+for(i=0;i<9;i++)
+x.fillRect(400+i*100+S(t)*300,400,50,200) // draw 50x200 rects</textarea>
       </div>
-      <code class="function-wrap">} //<div class=character-count>122/140</div>
+      <code class="function-wrap">} // <div class=character-count>122/140</div>
       </code>
       </br>
       <div class=error-display></div>


### PR DESCRIPTION
* Fix indentation issues of default dweet
* Code style tweaks to default dweet for consistency
  * Remove semicolon
  * Remove whitespace from commas
  * Change comments to line comments
* Add padding to editor to make `u(t)` function contents look indented
* Tweak `u(t)` function code style

It now looks like this:

![image](https://user-images.githubusercontent.com/50832/34573842-79893874-f143-11e7-8e7d-b48ae78968a3.png)

With this change, it will look like this:

![image](https://user-images.githubusercontent.com/50832/34573805-59e7d700-f143-11e7-8c30-3aa83c7a49b6.png)
