### PR TITLE
Make iframe body black

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -2,10 +2,13 @@
 <head>
   <style>
     * {padding:0;margin:0;border:0;outline:0;overflow:hidden}
+    body {
+      background: black;
+    }
     canvas {
       width: 100%;
       background: white;
-      }
+    }
     </style>
     <script>
       var autoplay = getURLParameter('autoplay');


### PR DESCRIPTION
In fullscreen mode, dweets that don't have a white background (or are not transparent) are displayed with an ugly white band at the bottom (i.e. when the screen's aspect ratio is not 16:9). Making the background black fixes this.