### PR TITLE
Remix info area fixes

### DIFF
--- a/dwitter/templates/snippets/remix_info.html
+++ b/dwitter/templates/snippets/remix_info.html
@@ -1,11 +1,11 @@
 {% load to_gravatar_url %}
 <div class="remix-info">
   remix of
-  <a href="{% url 'dweet_show' dweet_id=dweet.reply_to.id %}">#{{dweet.reply_to.id}}</a>
-  by
   {% if dweet.reply_to.deleted %}
     [deleted]
   {% else %}
+    <a href="{% url 'dweet_show' dweet_id=dweet.reply_to.id %}">#{{dweet.reply_to.id}}</a>
+    by
     <a href="{% url 'user_feed' url_username=dweet.reply_to.author.username %}">
       {{ dweet.reply_to.author.username }}
     </a>

--- a/dwitter/templates/snippets/remix_info.html
+++ b/dwitter/templates/snippets/remix_info.html
@@ -4,10 +4,10 @@
   {% if dweet.reply_to.deleted %}
     [deleted]
   {% else %}
-    <a href="{% url 'dweet_show' dweet_id=dweet.reply_to.id %}">#{{dweet.reply_to.id}}</a>
+    <a href="{% url 'dweet_show' dweet_id=dweet.reply_to.id %}">d/{{dweet.reply_to.id}}</a>
     by
     <a href="{% url 'user_feed' url_username=dweet.reply_to.author.username %}">
-      {{ dweet.reply_to.author.username }}
+      u/{{ dweet.reply_to.author.username }}
     </a>
     <div class="avatar" style="background-image: url({{ dweet.reply_to.author.email | to_gravatar_url }})"></div>
   {% endif %}


### PR DESCRIPTION
  > **Fix [deleted] message in dweet remix info area** 
Before, it would look like the user of the remixed dweet was deleted,
but really, it's the dweet itself that was deleted. Now, it looks more
like the latter.

> **Use proper d/ and u/ style in remix info area**
This can work as a way of letting users know what the syntax is for
linking to dweets and users in the comments.
>
>This fixes #250.