### PR TITLE
Add API to get JSON dweets and remixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ Inspired by [arkt.is/t/](http://arkt.is/t/Yy53aWR0aD0yZTM7eC5maWxsUmVjdCgxNTAsMT
 * `make shell`
 * `make backup`
 * `make restore-backup`
+
+
+# Dwitter API
+
+### Dweets
+```
+GET dwitter.net/api/dweets/  - list of the last 10 dweets
+       ?limit=100            - number of results to return, default 10, max 100 (subject to change)
+       &offset=200           - offset page by 200 dweets
+       &reply_to=123         - all remixes of 123
+       &author=lionleaf      - dweets by author
+```
+
+Latest dweet: `https://www.dwitter.net/api/dweets/?limit=1`  (sorted by posted date by default)
+
+
+### Users
+```
+GET dwitter.net/api/users/lionleaf  - Show details about user 'lionleaf'.
+```

--- a/dwitter/serializers.py
+++ b/dwitter/serializers.py
@@ -6,19 +6,31 @@ from django.template.defaultfilters import urlizetrunc
 
 
 class UserSerializer(serializers.ModelSerializer):
+    link = serializers.SerializerMethodField()
+    date_joined = serializers.DateTimeField(format="%Y-%m-%d")
+
     class Meta:
-        id = serializers.ReadOnlyField(source='pk')
         model = User
-        fields = ('id', 'username')
+        fields = ('username', 'date_joined', 'link')
+
+    def get_link(self, obj):
+        return 'https://www.dwitter.net/u/%s' % obj.username
 
 
 class CommentSerializer(serializers.ModelSerializer):
-    author = serializers.ReadOnlyField(source='author.username')
     urlized_text = serializers.SerializerMethodField()
+    author = serializers.SerializerMethodField()
+    reply_to = serializers.PrimaryKeyRelatedField(
+        queryset=Dweet.with_deleted.all()
+    )
+    id = serializers.ReadOnlyField(source='pk')
 
     class Meta:
         model = Comment
-        fields = ('pk', 'urlized_text', 'text', 'posted', 'reply_to', 'author')
+        fields = ('id', 'urlized_text', 'text', 'posted', 'author', 'reply_to')
+
+    def get_author(self, obj):
+        return obj.author.username
 
     def get_urlized_text(self, obj):
         return insert_magic_links(urlizetrunc(obj.text, 45))
@@ -30,16 +42,17 @@ class DweetSerializer(serializers.ModelSerializer):
         source='reply_to',
         queryset=Dweet.with_deleted.all()
     )
+    link = serializers.SerializerMethodField()
     awesome_count = serializers.SerializerMethodField()
-    author_name = serializers.SerializerMethodField()
+    author = UserSerializer()
 
     class Meta:
         model = Dweet
-        fields = ('id', 'code', 'posted', 'author', 'author_name', 'awesome_count',
+        fields = ('id', 'code', 'posted', 'author', 'link', 'awesome_count',
                   'remix_of')
-
-    def get_author_name(self, obj):
-        return obj.author.username
 
     def get_awesome_count(self, obj):
         return obj.likes.all().count()
+
+    def get_link(self, obj):
+        return 'https://www.dwitter.net/d/%i' % obj.id

--- a/dwitter/settings/base.py
+++ b/dwitter/settings/base.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
+    'django_filters',
     'rest_framework',
     'dwitter',
     'registration',
@@ -66,6 +67,8 @@ DBBACKUP_STORAGE_OPTIONS = {'location': 'backups'}
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+    'PAGE_SIZE': 10,                   # Default to 10
+    'MAX_PAGE_SIZE': 100,             # Maximum limit allowed when using `?page_size=xxx`.
 
 }
 

--- a/dwitter/templatetags/insert_magic_links.py
+++ b/dwitter/templatetags/insert_magic_links.py
@@ -1,6 +1,5 @@
 import re
 from django import template
-from django.core.urlresolvers import reverse
 
 register = template.Library()
 
@@ -11,9 +10,11 @@ def to_link(m):
     username = m.group('username')
 
     if username is None:
-        path = reverse('dweet_show', kwargs={'dweet_id': dweet_id})
+        path = '/d/' + dweet_id  # hardcode for speed!
+        # path = reverse('dweet_show', kwargs={'dweet_id': dweet_id})
     else:
-        path = reverse('user_feed', kwargs={'url_username': username})
+        path = '/u/' + username  # hardcode for speed!
+        # path = reverse('user_feed', kwargs={'url_username': username})
 
     return '<a href="%s">%s</a>' % (path, text)
 

--- a/dwitter/urls.py
+++ b/dwitter/urls.py
@@ -8,7 +8,8 @@ from django.conf import settings
 
 router = DefaultRouter()
 router.register(r'comments', views.CommentViewSet)
-router.register(r'd', views.DweetViewSet)
+router.register(r'dweets', views.DweetViewSet)
+router.register(r'users', views.UserViewSet)
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),

--- a/dwitter/urls.py
+++ b/dwitter/urls.py
@@ -8,8 +8,7 @@ from django.conf import settings
 
 router = DefaultRouter()
 router.register(r'comments', views.CommentViewSet)
-# WARNING! Enabling this might cause unauthorized dweet posting
-# router.register(r'dweets', views.DweetViewSet)
+router.register(r'd', views.DweetViewSet)
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),

--- a/dwitter/views.py
+++ b/dwitter/views.py
@@ -1,8 +1,11 @@
-from dwitter.models import Comment
+from dwitter.models import Comment, Dweet
 from dwitter.permissions import IsAuthorOrReadOnly
-from dwitter.serializers import CommentSerializer
+from dwitter.serializers import CommentSerializer, DweetSerializer
 from django.utils import timezone
-from rest_framework import viewsets, permissions
+from rest_framework import viewsets, mixins, permissions
+from rest_framework.response import Response
+from rest_framework.decorators import detail_route, list_route
+
 
 
 class CommentViewSet(viewsets.ModelViewSet):
@@ -14,3 +17,22 @@ class CommentViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(author=self.request.user, posted=timezone.now())
+
+class DweetViewSet( mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    queryset = Dweet.objects.all()
+    serializer_class = DweetSerializer
+
+    def perform_create(self, serializer):
+        serializer.save(author=self.request.user, posted=timezone.now())
+
+    @list_route()
+    def newest(self, request):
+        newest_dweet = Dweet.objects.latest(field_name='posted')
+        serializer = self.get_serializer(newest_dweet)
+        return Response(serializer.data)
+
+    @detail_route()
+    def remixes(self, request, pk=None):
+        remix_dweets = Dweet.objects.all().filter(reply_to=pk)
+        serializer = self.get_serializer(remix_dweets, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
/api/d/123  --> Dweet 123 in JSON

Example JSON response:

`{"id":4054,"code":"c.width=1920; /* clear the canvas */\r\n  for(i=0;i<9;i++)\r\n  x.fillRect(400+i*100+S(t)*300, 400, 50, 200) /* draw 50x200 rects test */","posted":"2017-12-30T23:19:57.490518Z","author":1,"author_name":"lionleaf","awesome_count":1,"remix_of":4053}`

/api/newest --> Newest dweet

JSON looks the same as for /api/d/XXX but will always show only the newest one (good for polling for new dweets)

/api/d/123/remixes --> all remixes of d/123



Thoughts? Is this the right way to do it? Or maybe for a more generic /api/d/  <--- list of all dweets and then add ?parameter= filters so you can do your own queries? Slightly worried about performance, but guess we can rate limit