### PR TITLE
Roll up anchor content to remove extra space

### DIFF
--- a/dwitter/templates/snippets/remix_info.html
+++ b/dwitter/templates/snippets/remix_info.html
@@ -6,9 +6,7 @@
   {% else %}
   <a href="{% url 'dweet_show' dweet_id=dweet.reply_to.id %}"><span class="faded">d/</span>{{dweet.reply_to.id}}</a>
     by
-    <a href="{% url 'user_feed' url_username=dweet.reply_to.author.username %}">
-        <span class="faded">u/</span>{{ dweet.reply_to.author.username }}
-    </a>
+    <a href="{% url 'user_feed' url_username=dweet.reply_to.author.username %}"><span class="faded">u/</span>{{ dweet.reply_to.author.username }}</a>
     <div class="avatar" style="background-image: url({{ dweet.reply_to.author.email | to_gravatar_url }})"></div>
   {% endif %}
 </div>


### PR DESCRIPTION
Currently, the anchor hangs beyond the username:

![image](https://user-images.githubusercontent.com/50832/34682426-e843cd20-f46c-11e7-8acf-ba75e5917685.png)

With this fix:

![image](https://user-images.githubusercontent.com/50832/34682444-f476cebc-f46c-11e7-8eb0-ca9082f054a0.png)
