### PR TITLE
add about page stub

### DIFF
--- a/dwitter/templates/about.html
+++ b/dwitter/templates/about.html
@@ -35,7 +35,7 @@
 
     <br />
     <p>
-    Please join us in the <a href="https://discordapp.com/channels/395956681793863690">discord chat</a> to hang out, ask for coding help, or discuss anything :D See you there!
+    Please join us in the <a href="https://discordapp.com/channels/395956681793863690">discord chat</a> to hang out, ask for coding help, or discuss anything :D If you don't know where to start and want to learn, this is the perfect place to start. See you there!
     </p>
     <br />
     <p>

--- a/dwitter/templates/about.html
+++ b/dwitter/templates/about.html
@@ -15,16 +15,19 @@
     <h2 class=header-title>About dwitter.net</h2>
     <p>
     <br />
-    Dwitter is a platform to create and share visual art written in 140 characters of javascript.
+    Dwitter.net is a challenge to see what awesomeness you can create when limited to only 140 characters of javascript and a canvas. Give it a go!
 
-    It was created by <a href='u/lionleaf'>u/lionleaf</a> as a side project inspired by the concept of <a href='u/lionleaf'>u/sigveseb</a> at arkt.is/t (github).
+    <br />
+    <br />
+
+    It was created by <a href='u/lionleaf'>u/lionleaf</a> as a side project inspired by the concept of <a href='u/sigveseb'>u/sigveseb</a> at <a href='http://arkt.is/t/Yy53aWR0aD0yZTM7dCo9Mzt4LnRyYW5zbGF0ZSg5ODAsNDUwKTtmb3IoaT0wO2k8MzIyOyl4LmZpbGxTdHlsZT1SKGkpLHgucm90YXRlKCFpKkModC09LjAzKSshKGkrKyU0KSpTKHQpLzkrMS41NykseC5maWxsUmVjdCg1KmksNSppLDk5LDk5KQ=='>arkt.is/t</a> (<a href='https://github.com/sigvef/arktis-tweet-demo'>github</a>).
 
     Its first official launch was at the Demoparty 'Solskogen' in 2016 where it won <a href=http://www.pouet.net/prod.php?which=67794>the wild compo.</a>
     </p>
     
     <br />
     <p>
-    The website itself is open source, and is being developed by a number of contributors. We are happy to accept pull requests and issues on <a href="https://github.com/lionleaf/dwitter">github</a>.
+    The website itself is open source, and is being developed by a number of <a href='https://github.com/lionleaf/dwitter/graphs/contributors'>contributors</a>. We are happy to accept pull requests and issues on <a href="https://github.com/lionleaf/dwitter">github</a>.
     <br />
     Check out the <a href="https://github.com/lionleaf/dwitter/issues">issue tracker</a> for previous suggestions and discussions.
     <br />
@@ -33,6 +36,10 @@
     <br />
     <p>
     Please join us in the <a href="https://discordapp.com/channels/395956681793863690">discord chat</a> to hang out, ask for coding help, or discuss anything :D See you there!
+    </p>
+    <br />
+    <p>
+    <b>Contact</b> <br/> <a href='https://twitter.com/lionleaf'>twitter.com/lionleaf</a> and <a href='https://twitter.com/sigvef'>twitter.com/sigvef</a> or <b>@lionleaf</b> and <b>@sigveseb</b> on <a href="https://discordapp.com/channels/395956681793863690">discord</a>
     </p>
 
 

--- a/dwitter/templates/about.html
+++ b/dwitter/templates/about.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+    <h2 class=header-title>About Dwitter</h2>
+    <p>
+        Dwitter is a social network for short js demos.
+    </p>
+
+    <hr>
+
+    <a href="https://github.com/lionleaf/dwitter">git repo</a>
+    <br>
+    <a href="https://github.com/lionleaf/dwitter/issues">issue tracker</a>
+    <br>
+    <a href="https://discordapp.com/channels/395956681793863690">discord chat</a>
+
+{% endblock %}
+

--- a/dwitter/templates/about.html
+++ b/dwitter/templates/about.html
@@ -1,19 +1,41 @@
 {% extends 'base.html' %}
 
+{% block top-nav %}
+<ul class=top-sort-list>
+  <li><a class="hot" href="{% url 'hot_feed' %}">hot</a></li>
+  <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
+  <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
+  <li><a class="random" href="{% url 'random_feed' %}">random</a></li>
+  <li><b><a class="about" href="{% url 'about' %}">about</a></b></li>
+</ul>
+{% endblock %}
+
 {% block content %}
 
-    <h2 class=header-title>About Dwitter</h2>
+    <h2 class=header-title>About dwitter.net</h2>
     <p>
-        Dwitter is a social network for short js demos.
+    <br />
+    Dwitter is a platform to create and share visual art written in 140 characters of javascript.
+
+    It was created by <a href='u/lionleaf'>u/lionleaf</a> as a side project inspired by the concept of <a href='u/lionleaf'>u/sigveseb</a> at arkt.is/t (github).
+
+    Its first official launch was at the Demoparty 'Solskogen' in 2016 where it won <a href=http://www.pouet.net/prod.php?which=67794>the wild compo.</a>
+    </p>
+    
+    <br />
+    <p>
+    The website itself is open source, and is being developed by a number of contributors. We are happy to accept pull requests and issues on <a href="https://github.com/lionleaf/dwitter">github</a>.
+    <br />
+    Check out the <a href="https://github.com/lionleaf/dwitter/issues">issue tracker</a> for previous suggestions and discussions.
+    <br />
     </p>
 
-    <hr>
+    <br />
+    <p>
+    Please join us in the <a href="https://discordapp.com/channels/395956681793863690">discord chat</a> to hang out, ask for coding help, or discuss anything :D See you there!
+    </p>
 
-    <a href="https://github.com/lionleaf/dwitter">git repo</a>
-    <br>
-    <a href="https://github.com/lionleaf/dwitter/issues">issue tracker</a>
-    <br>
-    <a href="https://discordapp.com/channels/395956681793863690">discord chat</a>
+
 
 {% endblock %}
 

--- a/dwitter/templates/feed/feed.html
+++ b/dwitter/templates/feed/feed.html
@@ -33,6 +33,7 @@
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
   <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
   <li><a class="random" href="{% url 'random_feed' %}">random</a></li>
+  <li><a class="about" href="{% url 'about' %}">about</a></li>
   {%elif feed_type == "user" %}
   <li><a class="new" href="{% url 'user_sort_feed' sort='new' url_username=feed_user %}">new</a></li>
   <li><a class="top" href="{% url 'user_sort_feed' sort='top' url_username=feed_user %}">top</a></li>

--- a/dwitter/urls.py
+++ b/dwitter/urls.py
@@ -36,6 +36,10 @@ urlpatterns = [
         auth_views.password_reset_confirm,
         name='password_reset_confirm'),
     url(r'^accounts/', include('registration.backends.simple.urls')),
+    url(r'^about$',
+        views.about,
+        name='about'),
+
 
     url(r'^accounts/password/reset/confirm', auth_views.password_change),
     url(r'^u/', include('dwitter.user.urls')),

--- a/dwitter/views.py
+++ b/dwitter/views.py
@@ -1,6 +1,5 @@
 from dwitter.models import Comment, Dweet
 from django.shortcuts import render
-from dwitter.models import Comment
 from dwitter.permissions import IsAuthorOrReadOnly
 from dwitter.serializers import CommentSerializer, DweetSerializer
 from dwitter.serializers import UserSerializer

--- a/dwitter/views.py
+++ b/dwitter/views.py
@@ -1,4 +1,6 @@
 from dwitter.models import Comment, Dweet
+from django.shortcuts import render
+from dwitter.models import Comment
 from dwitter.permissions import IsAuthorOrReadOnly
 from dwitter.serializers import CommentSerializer, DweetSerializer
 from dwitter.serializers import UserSerializer
@@ -47,3 +49,7 @@ class UserViewSet(mixins.RetrieveModelMixin,
     queryset = User.objects.all()
     serializer_class = UserSerializer
     lookup_field = 'username'
+
+
+def about(request):
+    return render(request, 'about.html')


### PR DESCRIPTION
Re-opening of #258 by @whackashoe Thanks for kick-starting this!

Moved to a local branch, so additional commits can be added to the branch `about_page`

Current state:

<img width="815" alt="screen shot 2018-01-17 at 9 21 16 pm" src="https://user-images.githubusercontent.com/610925/35083153-86d6a266-fbd2-11e7-9674-5e3a48a9b19b.png">
<img width="863" alt="screen shot 2018-01-17 at 9 21 36 pm" src="https://user-images.githubusercontent.com/610925/35083156-88d75bf0-fbd2-11e7-8fda-dd3e1c11b978.png">


Feedback welcome both as responses here and as commits directly to the pull request :D
