### PR TITLE
Backticks for code blocks

### DIFF
--- a/dwitter/serializers.py
+++ b/dwitter/serializers.py
@@ -40,7 +40,12 @@ class CommentSerializer(serializers.ModelSerializer):
         return obj.author.username
 
     def get_urlized_text(self, obj):
-        return insert_magic_links(urlizetrunc(insert_code_blocks(obj.text), 45))
+        return insert_magic_links(
+            urlizetrunc(
+                insert_code_blocks(obj.text),
+                45
+            )
+        )
 
 
 class DweetSerializer(serializers.ModelSerializer):

--- a/dwitter/serializers.py
+++ b/dwitter/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from dwitter.models import Dweet, Comment
+from dwitter.templatetags.insert_code_blocks import insert_code_blocks
 from dwitter.templatetags.insert_magic_links import insert_magic_links
 from dwitter.templatetags.to_gravatar_url import to_gravatar_url
 from django.contrib.auth.models import User
@@ -39,7 +40,7 @@ class CommentSerializer(serializers.ModelSerializer):
         return obj.author.username
 
     def get_urlized_text(self, obj):
-        return insert_magic_links(urlizetrunc(obj.text, 45))
+        return insert_magic_links(urlizetrunc(insert_code_blocks(obj.text), 45))
 
 
 class DweetSerializer(serializers.ModelSerializer):

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -196,6 +196,10 @@ ul.messages li.success{
   word-wrap: break-word;
 }
 
+.comment-message code {
+  background: #eee;
+}
+
 .new-comment {
   margin-top: 10px;
   display: flex;

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -1,6 +1,7 @@
 {% load subdomainurls %}
 {% load to_gravatar_url %}
 {% load insert_magic_links %}
+{% load insert_code_blocks %}
 <div class=dweet-wrapper>
   <div class=dweet >
     <div class=canvas-iframe-container-wrapper>
@@ -78,7 +79,7 @@
     <ul class=sticky-comments>
       <li class="comment sticky-comment">
         <a class="comment-name sticky-comment" href="{% url 'user_feed' url_username=dweet.comments.last.author.username %}">{{ dweet.comments.last.author.username }}:</a>
-        <span class="comment-message sticky-comment">{{ dweet.comments.last.text | urlizetrunc:45 | insert_magic_links }}</span>
+        <span class="comment-message sticky-comment">{{ dweet.comments.last.text | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
       </li>
       </ul>
         {% endif %}
@@ -98,7 +99,7 @@
       {% if comment != dweet.comments.last or dweet.comments.last.author != dweet.author  %}
       <li class=comment>
       <a class=comment-name href="{% url 'user_feed' url_username=comment.author.username %}">{{ comment.author.username }}:</a>
-      <span class="comment-message">{{ comment.text | urlizetrunc:45 | insert_magic_links }}</span>
+      <span class="comment-message">{{ comment.text | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
       </li>
       {% endif %}
       {% endfor %}

--- a/dwitter/templatetags/insert_code_blocks.py
+++ b/dwitter/templatetags/insert_code_blocks.py
@@ -1,0 +1,25 @@
+import re
+from django import template
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+def to_code_block(m):
+    code = m.group('code')
+    code = re.sub(r'\\`', '`', code)
+
+    return '<code>%s</code>' % (escape(code))
+
+
+@register.filter
+def insert_code_blocks(text):
+    result = re.sub(
+        r'`'            # start with `
+        r'(?P<code>.*)' # capture code block
+        r'(?<!\\)'      # not preceded by \
+        r'`',           # end with `
+        to_code_block,
+        text
+    )
+    return mark_safe(result)

--- a/dwitter/templatetags/insert_code_blocks.py
+++ b/dwitter/templatetags/insert_code_blocks.py
@@ -5,6 +5,7 @@ from django.utils.safestring import mark_safe
 
 register = template.Library()
 
+
 def to_code_block(m):
     code = m.group('code')
     code = re.sub(r'\\`', '`', code)
@@ -15,10 +16,10 @@ def to_code_block(m):
 @register.filter
 def insert_code_blocks(text):
     result = re.sub(
-        r'`'            # start with `
-        r'(?P<code>.*)' # capture code block
-        r'(?<!\\)'      # not preceded by \
-        r'`',           # end with `
+        r'`'                # start with `
+        r'(?P<code>.*)'     # capture code block
+        r'(?<!\\)'          # not preceded by \
+        r'`',               # end with `
         to_code_block,
         text
     )

--- a/dwitter/tests/templatetags/test_insert_code_blocks.py
+++ b/dwitter/tests/templatetags/test_insert_code_blocks.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+from dwitter.templatetags.insert_code_blocks import insert_code_blocks
+
+
+class DweetTestCase(TestCase):
+    def test_insert_code_blocks_wraps_stuff_inside_backticks(self):
+        self.assertEqual(
+            '<code>a</code>',
+            insert_code_blocks('`a`')
+        )
+
+    def test_insert_code_blocks_ignored_backticks(self):
+        self.assertEqual(
+            '<code>a=`b`</code>',
+            insert_code_blocks('`a=\`b\``')
+        )


### PR DESCRIPTION
Converts stuff between `` ` `` and `` ` `` to `<code>` blocks, except when a `` ` `` is escaped with a `` \` ``