### PR TITLE
Make code block regex non-greedy

### DIFF
--- a/dwitter/templatetags/insert_code_blocks.py
+++ b/dwitter/templatetags/insert_code_blocks.py
@@ -17,7 +17,7 @@ def to_code_block(m):
 def insert_code_blocks(text):
     result = re.sub(
         r'`'                # start with `
-        r'(?P<code>.*)'     # capture code block
+        r'(?P<code>.*?)'    # capture code block
         r'(?<!\\)'          # not preceded by \
         r'`',               # end with `
         to_code_block,

--- a/dwitter/tests/templatetags/test_insert_code_blocks.py
+++ b/dwitter/tests/templatetags/test_insert_code_blocks.py
@@ -9,8 +9,14 @@ class DweetTestCase(TestCase):
             insert_code_blocks('`a`')
         )
 
-    def test_insert_code_blocks_ignored_backticks(self):
+    def test_insert_code_blocks_ignores_backticks(self):
         self.assertEqual(
             '<code>a=`b`</code>',
             insert_code_blocks('`a=\`b\``')
+        )
+
+    def test_insert_code_blocks_is_not_greedy_with_multiple_blocks(self):
+        self.assertEqual(
+            'a <code>1</code> b <code>2</code> c',
+            insert_code_blocks('a `1` b `2` c')
         )


### PR DESCRIPTION
Example: Qwitter's first comment on https://www.dwitter.net/d/6297 renders as:

> It does work the same w/o `` beginPath` on the phone's Safari browser, and i was able to get a little color with `x.fillStyle=R(p); ``.

Should look like:

> It does work the same w/o `beginPath` on the phone's Safari browser, and i was able to get a little color with `x.fillStyle=R(p);`.