### PR TITLE
Add support for embedding dweets on external sites

### DIFF
--- a/dwitter/feed/urls.py
+++ b/dwitter/feed/urls.py
@@ -36,5 +36,8 @@ urlpatterns = [
         views.dweet_delete, name='dweet_delete'),
     url(r'^d/(?P<dweet_id>\d+)/like$', views.like, name='like'),
 
+    url(r'^e/(?P<dweet_id>\d+)$',
+        views.dweet_embed, name='dweet_embed'),
+
     url(r'^dweet$', views.dweet, name='dweet'),
 ]

--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.http import HttpResponseRedirect, HttpResponse
 from django.http import Http404, HttpResponseBadRequest
 from django.core.urlresolvers import reverse
@@ -119,6 +120,17 @@ def dweet_show(request, dweet_id):
     }
 
     return render(request, 'feed/permalink.html', context)
+
+
+@xframe_options_exempt
+def dweet_embed(request, dweet_id):
+    dweet = get_object_or_404(Dweet.with_deleted.annotate(
+        num_likes=Count('likes')), id=dweet_id)
+    context = {
+        'dweet': dweet
+    }
+
+    return render(request, 'feed/embed.html', context)
 
 
 @login_required

--- a/dwitter/static/js/ajax-handling.js
+++ b/dwitter/static/js/ajax-handling.js
@@ -4,7 +4,8 @@ function processLike(e) {
   var $likeButton = $likeForm.find('.like-button');
   var processServerResponse = function(response) {
     if (response.not_authenticated) {
-      window.location = '/accounts/login/';
+      $likeForm.parent().parent().find('.error-display')[0]
+        .innerText = 'You have to be logged in to vote';
     } else {
       $likeButton.find('.score-text').html(response.likes);
       if (response.liked) {

--- a/dwitter/static/js/feed.js
+++ b/dwitter/static/js/feed.js
@@ -32,6 +32,8 @@ $(document).ready(function() {
     var iframe = $(el).find('iframe.dweetiframe');
     var sharebutt = $(el).find('.share-button');
     var sharelink = $(el).find('.share-link');
+    var embedbutt = $(el).find('.embed-button');
+    var embedsrc = $(el).find('.embed-src');
 
     link.on('click', function(e) {
       e.preventDefault();
@@ -41,12 +43,28 @@ $(document).ready(function() {
     sharebutt.on('click', function(e) {
       e.preventDefault();
       sharelink.toggle();
+      embedsrc.hide();
       if (sharelink.is(':visible')) {
         sharelink.select();
       }
     });
 
     $(sharelink).focus(function() {
+      $(this).on('click.a keyup.a', function() {
+        $(this).off('click.a keyup.a').select();
+      });
+    });
+
+    embedbutt.on('click', function(e) {
+      e.preventDefault();
+      embedsrc.toggle();
+      sharelink.hide();
+      if (embedsrc.is(':visible')) {
+        embedsrc.select();
+      }
+    });
+
+    $(embedsrc).focus(function() {
       $(this).on('click.a keyup.a', function() {
         $(this).off('click.a keyup.a').select();
       });

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -104,6 +104,9 @@ body{
   line-height: 1.58;
   letter-spacing: -0.003;
 }
+body.embed{
+  background:#ffffff;
+}
 
 code {
   font-family: Pragmata, Menlo, 'DejaVu LGC Sans Mono', 'DejaVu Sans Mono', Consolas, 'Everson Mono', 'Lucida Console', 'Andale Mono', 'Nimbus Mono L', 'Liberation Mono', FreeMono, 'Osaka Monospaced', Courier, 'New Courier', monospace;
@@ -507,12 +510,13 @@ form.like {
   display: initial;
 }
 
-.fullscreen-button, .share-button, .show-stats, .hide-stats {
+.dweet-option {
   flex-grow: 0;
   padding:5px;
 }
 
-.share-link {
+.share-link,
+.embed-src {
   width:15em;
   display:none;
   position: absolute;

--- a/dwitter/templates/feed/embed.html
+++ b/dwitter/templates/feed/embed.html
@@ -1,0 +1,59 @@
+{% load subdomainurls %}
+{% load staticfiles %}
+{% load compress %}
+
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        {% compress js %}
+        <!-- Google Analytics! -->
+        <script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-76510271-1', 'auto');
+ga('send', 'pageview');
+
+        </script>
+        {% endcompress %}
+
+        {% load staticfiles %}
+        <link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i" rel="stylesheet">
+        {% compress css %}
+        <link rel=stylesheet href='{% static "main.css" %}' >
+        {% endcompress %}
+
+        {% compress js %}
+        <script src="{% static "libs/jquery.min.js" %}"></script>
+        <script src="{% static "libs/jquery.waypoints.min.js" %}"></script>
+        <script src="{% static "libs/inview.min.js" %}"></script>
+        <script src="{% static "libs/infinite.min.js" %}"></script>
+        <script src="{% static "libs/moment-with-locales.min.js" %}"></script>
+        {% endcompress %}
+
+        {% load staticfiles %}
+        {% load compress %}
+        {% compress js %}
+        <script src="{% static "js/scrolling.js" %}"></script>
+        <script src="{% static "js/ajax-handling.js" %}"></script>
+        <script src="{% static "js/feed.js" %}"></script>
+        <!--<script src="{% static 'js/submit-view.js' %}"></script> -->
+        {% endcompress %}
+
+    </head>
+    <body class='embed'>
+
+            {% if dweet.deleted %}
+            {% include 'snippets/deleted_dweet_card.html' %}
+            {% else %}
+            {% include 'snippets/dweet_card.html' with embed=True %}
+            {% endif %}
+
+    </body>
+</html>
+
+

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -18,10 +18,13 @@
           <span class="like-text">Awesome!</span>
         </button>
       </form>
-      <a class="show-stats" href="javascript:;" target="_blank">show FPS</a>
-      <a class="hide-stats" href="javascript:;" target="_blank">hide FPS</a>
-      <a class=fullscreen-button href="javascript:;" target="_blank">fullscreen</a>
-      <a class=share-button href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">share</a>
+      <a class="dweet-option show-stats" href="javascript:;" target="_blank">show FPS</a>
+      <a class="dweet-option hide-stats" href="javascript:;" target="_blank">hide FPS</a>
+      {% if embed %}
+      <a class="dweet-option embed-dwitter-link"  href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">full version</a>
+      {% endif %}
+      <a class="dweet-option share-button" href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">share</a>
+      <a class="dweet-option embed-button" href="" target="_blank">embed</a>
       {% if request.user == dweet.author or request.user.is_staff %}
         <form class="dweet-delete-form" action="{% url 'dweet_delete' dweet_id=dweet.id %}" method="post"
           onsubmit="return confirm('Are you sure you want to delete the dweet (cannot be reversed)?');" >
@@ -32,7 +35,9 @@
           value="delete" />
         </form>
       {% endif %}
+      <a class="dweet-option fullscreen-button" href="javascript:;" target="_blank">fullscreen</a>
       <input type=text readonly class=share-link value='{% url 'dweet_show' dweet_id=dweet.id %}'/>
+      <input type=text readonly class=embed-src value='<iframe width=500 height=550 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}"></iframe>'/>
     </div>
     <div class=author-remix-wrapper>
       <div class=dweet-author>
@@ -74,6 +79,7 @@
         </form>
     </div>
   </div>
+  {% if not embed %}
   <div class=comment-section>
     {% if dweet.comments.last.author == dweet.author %}
     <ul class=sticky-comments>
@@ -113,4 +119,5 @@
       {%endif%}
     </form>
   </div>
+  {% endif %}
 </div>

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -37,7 +37,7 @@
       {% endif %}
       <a class="dweet-option fullscreen-button" href="javascript:;" target="_blank">fullscreen</a>
       <input type=text readonly class=share-link value='{% url 'dweet_show' dweet_id=dweet.id %}'/>
-      <input type=text readonly class=embed-src value='<iframe width=500 height=550 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}"></iframe>'/>
+      <input type=text readonly class=embed-src value='<iframe width=500 height=550 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}" allowFullScreen="true"></iframe>'/>
     </div>
     <div class=author-remix-wrapper>
       <div class=dweet-author>

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -37,7 +37,7 @@
       {% endif %}
       <a class="dweet-option fullscreen-button" href="javascript:;" target="_blank">fullscreen</a>
       <input type=text readonly class=share-link value='{% url 'dweet_show' dweet_id=dweet.id %}'/>
-      <input type=text readonly class=embed-src value='<iframe width=500 height=550 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}" allowFullScreen="true"></iframe>'/>
+      <input type=text readonly class=embed-src value='<iframe width=500 height=570 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}" allowFullScreen="true"></iframe>'/>
     </div>
     <div class=author-remix-wrapper>
       <div class=dweet-author>
@@ -66,6 +66,7 @@
       </br>
       <div class=error-display></div>
       <div class=dweet-changed>
+            {% if not embed %}
             {% if request.user.is_authenticated %}
             <input
                 class="remix-button"
@@ -74,6 +75,7 @@
             {% else %}
               <br />
               <p>Please <a href="{% url 'auth_login' %}">log in</a> (or <a href="{% url 'register'  %}" >register</a>) to post as a new dweet (copy-paste code somewhere safe to save it meanwhile).</p>
+            {% endif %}
             {% endif %}
           </div>
         </form>


### PR DESCRIPTION
Adds a new url /e/DWEET_ID that is a bare-bones display of the dweet
without comments, this can be easily embedded on external sites
(cross-origin policy allows it too!) in an iframe.

ie: <iframe width=500 height=550 frameBorder="0" src="https://www.dwitter.net/e/123">
</iframe>

(width and height is flexible)

(ignore the DjDT in the picture, it's only for debugging)
<img width="595" alt="screen shot 2018-01-28 at 12 51 51 am" src="https://user-images.githubusercontent.com/610925/35480560-85deefe4-03c5-11e8-9008-ff065aaafc10.png">


embed link added to all dweets (and in the process I moved the fullscreen button to the very right, even when you can see the delete button)

<img width="350" alt="screen shot 2018-01-27 at 11 45 03 pm" src="https://user-images.githubusercontent.com/610925/35480094-20ece1c6-03bc-11e8-83a5-fd387c26c252.png">
<img width="404" alt="screen shot 2018-01-27 at 11 45 07 pm" src="https://user-images.githubusercontent.com/610925/35480096-23534e46-03bc-11e8-8db8-8b16d9c242b4.png">


fixes #220 


(there are some minor styling issues with the error text and size of the iframe)
<img width="587" alt="screen shot 2018-01-28 at 12 52 18 am" src="https://user-images.githubusercontent.com/610925/35480565-9697110e-03c5-11e8-8ee4-a1f7a8c6c7bc.png">

