### PR TITLE
Escape comment text to prevent simple script injection

### DIFF
--- a/dwitter/serializers.py
+++ b/dwitter/serializers.py
@@ -5,6 +5,7 @@ from dwitter.templatetags.insert_magic_links import insert_magic_links
 from dwitter.templatetags.to_gravatar_url import to_gravatar_url
 from django.contrib.auth.models import User
 from django.template.defaultfilters import urlizetrunc
+from django.utils.html import escape
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -42,7 +43,7 @@ class CommentSerializer(serializers.ModelSerializer):
     def get_urlized_text(self, obj):
         return insert_magic_links(
             urlizetrunc(
-                insert_code_blocks(obj.text),
+                insert_code_blocks(escape(obj.text)),
                 45
             )
         )

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -156,6 +156,7 @@
         stats.end();
         displayError("");
       } catch (e) {
+        stats.end();
         displayError(e);
         throw e;
       }

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -60,9 +60,10 @@
 
       function newCode(code) {
           try {
-            eval("u = function(t){"+code+"\n};");
+            eval("function u(t) {\n"+code+"\n}");
+            window.u = u;
           } catch (e) {
-            u = function(t){
+            window.u = function(t) {
               throw e;
             };
             throw e;


### PR DESCRIPTION
This should fix the issue around simple script injection into dweet comments. I've not tested this. As it is right now you can simply enter `<script>anything</script>`.