### PR TITLE
Disable compressor of css file as it breaks the dark theme

### DIFF
--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -22,9 +22,7 @@
 
     {% load staticfiles %}
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i" rel="stylesheet">
-    {% compress css %}
     <link id='style' rel=stylesheet href='{% static "main.css" %}' >
-    {% endcompress %}
 
     {% block head %}
     {% endblock %}


### PR DESCRIPTION
Figure out a way to do it with the compress enabled at some other time