### PR TITLE
Move user menu back to working position

### DIFF
--- a/dwitter/static/main_dark.css
+++ b/dwitter/static/main_dark.css
@@ -399,7 +399,6 @@ iframe {
   opacity: 0;
   height: 0;
   margin-top: 6px !important;
-  right: -25px !important;
   font-size: 0.8em;
 }
 


### PR DESCRIPTION
Put the right margin back to default to fix misalignments on smaller screens.