### PR TITLE
Various dark theme improvements for usernames and user menus

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -392,7 +392,7 @@ iframe {
 .head-account-info .collapsible {
   position: absolute;
   border: 1px solid #ddd;
-  right: 1em;
+  right: 0.7em;
   z-index: 10;
   transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
   opacity: 0;

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -397,7 +397,7 @@ iframe {
   transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
   opacity: 0;
   height: 0;
-  margin-top: -9999px;
+  margin-top: 7px !important;
   font-size: 0.8em;
 }
 

--- a/dwitter/static/main_dark.css
+++ b/dwitter/static/main_dark.css
@@ -393,13 +393,12 @@ iframe {
 .head-account-info .collapsible {
   position: absolute;
   border: 1px solid black !important;
-  right: 1em;
+  right: 0.7em;
   z-index: 10;
   transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
   opacity: 0;
   height: 0;
   margin-top: 6px !important;
-  right: -25px !important;
   font-size: 0.8em;
 }
 

--- a/dwitter/static/main_dark.css
+++ b/dwitter/static/main_dark.css
@@ -398,7 +398,7 @@ iframe {
   transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
   opacity: 0;
   height: 0;
-  margin-top: 6px !important;
+  margin-top: 7px !important;
   font-size: 0.8em;
 }
 

--- a/dwitter/static/main_dark.css
+++ b/dwitter/static/main_dark.css
@@ -744,7 +744,7 @@ body{
 }
 
 .comment-name{
-  color: black;
+  color: #ffa500;
 }
 
 textarea{


### PR DESCRIPTION
I'm not sure you've seen my suggestion about 0.7em margins, but I've now tested them and they look good on mobile and PC. Also made commenter usernames orange for readability and because it looks so much better that way. I think I'm now done with the dark theme, and can't seem to figure out a way to compress-css it, so this is probably my last PR for now :D. Also improved the description and topics for the repo -- feel free to put those back if you want.