### PR TITLE
Stop menu from being clickable when invisible

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -395,6 +395,7 @@ iframe {
   right: 0.7em;
   z-index: 10;
   transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
+  display: none;
   opacity: 0;
   height: 0;
   margin-top: 7px !important;

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -395,8 +395,8 @@ iframe {
   right: 0.7em;
   z-index: 10;
   transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
-  display: none;
   opacity: 0;
+  pointer-events: none;
   height: 0;
   margin-top: 7px !important;
   font-size: 0.8em;
@@ -409,6 +409,7 @@ iframe {
 .head-account-info.is-logged-in:hover .collapsible {
   display: block;
   opacity: 1;
+  pointer-events: auto;
   margin-top: 4px;
   transition: opacity 0.05s ease-in-out, margin 0.05s step-start;
 }

--- a/dwitter/static/main_dark.css
+++ b/dwitter/static/main_dark.css
@@ -396,6 +396,7 @@ iframe {
   right: 0.7em;
   z-index: 10;
   transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
+  display: none;
   opacity: 0;
   height: 0;
   margin-top: 7px !important;

--- a/dwitter/static/main_dark.css
+++ b/dwitter/static/main_dark.css
@@ -396,8 +396,8 @@ iframe {
   right: 0.7em;
   z-index: 10;
   transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
-  display: none;
   opacity: 0;
+  pointer-events: none;
   height: 0;
   margin-top: 7px !important;
   font-size: 0.8em;
@@ -410,6 +410,7 @@ iframe {
 .head-account-info.is-logged-in:hover .collapsible {
   display: block;
   opacity: 1;
+  pointer-events: auto;
   margin-top: 4px;
   transition: opacity 0.05s ease-in-out, margin 0.05s step-start;
 }


### PR DESCRIPTION
When the profile dropdown menu is hidden, it can still be clicked. Try it!

This is especially an issue for low-res displays, where the invisible menu takes up a large proportion of the screen, so it can easily be tapped accidentally.

We could have used `display: none` to hide the menu. But this would prevent the `opacity` transition from being seen.

So instead I used `pointer-events: none` to make the menu un-clickable when it is hidden/collapsed.

(Actually the opacity transition is so fast I can hardly notice it. But since a previous developer put it there, I tried to keep it.)

*I have not tested this code!* Please comment if it works for you, on PC or on mobile.