### PR TITLE
Repair positioning of dropdown menu

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -392,12 +392,12 @@ iframe {
 .head-account-info .collapsible {
   position: absolute;
   border: 1px solid #ddd;
-  right: 0.7em;
+  right: 1rem;
   z-index: 10;
-  transition: opacity 0.05s ease-in-out, margin 0.05s step-end;
+  transition: opacity .1s ease-in-out, margin .1s step-end;
   opacity: 0;
   height: 0;
-  margin-top: 7px !important;
+  margin-top: -9999px;
   font-size: 0.8em;
 }
 
@@ -408,8 +408,8 @@ iframe {
 .head-account-info.is-logged-in:hover .collapsible {
   display: block;
   opacity: 1;
-  margin-top: 4px;
-  transition: opacity 0.05s ease-in-out, margin 0.05s step-start;
+  margin-top: 0;
+  transition: opacity .1s ease-in-out, margin .1s step-start;
 }
 
 .head-account-info .collapsible li {


### PR DESCRIPTION
With changes to the dark theme, the margins of the dropdown were
updated, but I couldn't figure out why that change was made. Anyway,
this restores the hidden dropdown menu to waaaay off screen so it can
not be clicked when hidden. I also halved the speed of the animation and
adjusted the positioning so it perfectly aligns with the username and
avatar.

This should resolve issues on both desktop on mobile where you try and
press a link somewhere on the page and accidentally click something in
the ghost menu instead.

<img width="270" alt="screenshot 2018-03-31 15 15 37" src="https://user-images.githubusercontent.com/1413267/38163579-67b31c72-34f6-11e8-9178-c16f3b222e30.png">
