### PR TITLE
Add overflow hidden to canvas wrappers

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -320,6 +320,7 @@ input.comment-submit:active {
   position: absolute;
   width:100%;
   top: 0; bottom: 0; left: 0; right: 0;
+  overflow: hidden;
 }
 iframe {
   width:100%;


### PR DESCRIPTION
This fixes one long-standing and mega-annoying issue on at least iPhone
for *all* dweets that override the width of the canvas (a common
technique).

Can we all take a moment to appreciate the fact that it took me two
years to get around to fixing this? 


As @rikard-io noted in #156 it was just a matter of hiding the overflow. This works because the wrapper div around the iframe has already hard-coded the aspect ratio to 16:9 using the classic `padding-bottom: 56.25%` trick.

This fixes #156 

Before:
<pre align=center><img height=350 alt src="https://user-images.githubusercontent.com/1413267/38163649-e62bcada-34f7-11e8-9fa6-96db76f90d9b.PNG"></pre>

After:
<pre align=center><img height=350 alt src="https://user-images.githubusercontent.com/1413267/38163650-e906b148-34f7-11e8-9ce8-32e757e06a83.PNG"></pre>