### PR TITLE
Revert "Merge sharing options into one popover"

### DIFF
--- a/dwitter/static/js/feed.js
+++ b/dwitter/static/js/feed.js
@@ -31,8 +31,9 @@ $(document).ready(function() {
     var link = $(el).find('.fullscreen-button');
     var iframe = $(el).find('iframe.dweetiframe');
     var sharebutt = $(el).find('.share-button');
-    var shareContainer = $(el).find('.share-container');
     var sharelink = $(el).find('.share-link');
+    var embedbutt = $(el).find('.embed-button');
+    var embedsrc = $(el).find('.embed-src');
 
     link.on('click', function(e) {
       e.preventDefault();
@@ -41,13 +42,29 @@ $(document).ready(function() {
 
     sharebutt.on('click', function(e) {
       e.preventDefault();
-      shareContainer.toggle();
+      sharelink.toggle();
+      embedsrc.hide();
       if (sharelink.is(':visible')) {
         sharelink.select();
       }
     });
 
     $(sharelink).focus(function() {
+      $(this).on('click.a keyup.a', function() {
+        $(this).off('click.a keyup.a').select();
+      });
+    });
+
+    embedbutt.on('click', function(e) {
+      e.preventDefault();
+      embedsrc.toggle();
+      sharelink.hide();
+      if (embedsrc.is(':visible')) {
+        embedsrc.select();
+      }
+    });
+
+    $(embedsrc).focus(function() {
       $(this).on('click.a keyup.a', function() {
         $(this).off('click.a keyup.a').select();
       });

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -515,21 +515,12 @@ form.like {
   padding:5px;
 }
 
-.share-container {
-  display: none;
+.share-link,
+.embed-src {
+  width:15em;
+  display:none;
   position: absolute;
   top: 2em;
-  background: white;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-  padding: 1em;
-}
-
-.share-container ul {
-  list-style-type: none;
-}
-
-.share-container li {
-  text-align: right;
 }
 
 .dweet-timestamp{

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -24,6 +24,7 @@
       <a class="dweet-option embed-dwitter-link"  href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">full version</a>
       {% endif %}
       <a class="dweet-option share-button" href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">share</a>
+      <a class="dweet-option embed-button" href="" target="_blank">embed</a>
       {% if request.user == dweet.author or request.user.is_staff %}
         <form class="dweet-delete-form" action="{% url 'dweet_delete' dweet_id=dweet.id %}" method="post"
           onsubmit="return confirm('Are you sure you want to delete the dweet (cannot be reversed)?');" >
@@ -35,18 +36,8 @@
         </form>
       {% endif %}
       <a class="dweet-option fullscreen-button" href="javascript:;" target="_blank">fullscreen</a>
-      <div class="share-container">
-        <ul>
-          <li>
-            <label>Permalink:</label>
-            <input type=text readonly class=share-link value='{% url 'dweet_show' dweet_id=dweet.id %}'/>
-          </li>
-          <li>
-            <label>Embed:</label>
-            <input type=text readonly class=embed-src value='<iframe width=500 height=570 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}" allowFullScreen="true"></iframe>'/>
-          </li>
-        </ul>
-      </div>
+      <input type=text readonly class=share-link value='{% url 'dweet_show' dweet_id=dweet.id %}'/>
+      <input type=text readonly class=embed-src value='<iframe width=500 height=570 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}" allowFullScreen="true"></iframe>'/>
     </div>
     <div class=author-remix-wrapper>
       <div class=dweet-author>


### PR DESCRIPTION
Reverts lionleaf/dwitter#309 for now


Major issue: Share button doesn't work on dweets that have been loaded in after scrolling to the bottom of the page.
Minor issue: #310 

