### PR TITLE
Merge sharing options into popover again

### DIFF
--- a/dwitter/static/js/feed.js
+++ b/dwitter/static/js/feed.js
@@ -27,47 +27,27 @@ $(document).ready(function() {
   $('body').on('input', '.code-input', onDweetChanged);
   $('.code-input').each(onDweetChanged);
 
-  $('.dweet').each(function(i, el) {
-    var link = $(el).find('.fullscreen-button');
-    var iframe = $(el).find('iframe.dweetiframe');
-    var sharebutt = $(el).find('.share-button');
-    var sharelink = $(el).find('.share-link');
-    var embedbutt = $(el).find('.embed-button');
-    var embedsrc = $(el).find('.embed-src');
+  $('body').on('click', '.fullscreen-button', function(e) {
+    var dweetCard = $(this).closest('.dweet');
+    var iframe = $(dweetCard).find('iframe.dweetiframe');
+    e.preventDefault();
+    requestFullscreen(iframe[0]);
+  });
 
-    link.on('click', function(e) {
-      e.preventDefault();
-      requestFullscreen(iframe[0]);
-    });
+  $('body').on('click', '.share-button', function(e) {
+    var dweetCard = $(this).closest('.dweet');
+    var shareContainer = $(dweetCard).find('.share-container');
+    var shareLink = $(dweetCard).find('.share-link');
+    e.preventDefault();
+    shareContainer.toggle();
+    if (shareLink.is(':visible')) {
+      shareLink.select();
+    }
+  });
 
-    sharebutt.on('click', function(e) {
-      e.preventDefault();
-      sharelink.toggle();
-      embedsrc.hide();
-      if (sharelink.is(':visible')) {
-        sharelink.select();
-      }
-    });
-
-    $(sharelink).focus(function() {
-      $(this).on('click.a keyup.a', function() {
-        $(this).off('click.a keyup.a').select();
-      });
-    });
-
-    embedbutt.on('click', function(e) {
-      e.preventDefault();
-      embedsrc.toggle();
-      sharelink.hide();
-      if (embedsrc.is(':visible')) {
-        embedsrc.select();
-      }
-    });
-
-    $(embedsrc).focus(function() {
-      $(this).on('click.a keyup.a', function() {
-        $(this).off('click.a keyup.a').select();
-      });
+  $('body').on('focus', '.share-link', function() {
+    $(this).on('click.a keyup.a', function() {
+      $(this).off('click.a keyup.a').select();
     });
   });
 

--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -46,8 +46,8 @@ window.onload = function() {
       $.each(items, function(index, div) {
         var iframe = $(div).find('.dweetiframe')[0];
         var link = $(div).find('.fullscreen-button');
-        var sharebutt = $(div).find('.share-button');
-        var sharelink = $(div).find('.share-link');
+        var timestamp = $(div).find('time');
+        var postedDate = moment.utc(timestamp.attr('datetime'));
 
         registerOnKeyListener(div);
         registerStatsClickListeners(div);
@@ -59,26 +59,8 @@ window.onload = function() {
           requestFullscreen(iframe);
         });
 
-        sharebutt.on('click', function(e) {
-          e.preventDefault();
-          sharelink.toggle();
-
-          if (sharelink.is(':visible')) {
-            sharelink.select();
-          }
-        });
-
-        $(sharelink).focus(function() {
-          var timestamp = $(div).find('time');
-          var postedDate = moment.utc(timestamp.attr('datetime'));
-
-          moment.locale(navigator.userLanguage || navigator.language || 'en-US');
-          timestamp.text(postedDate.local().format('lll'));
-
-          $(this).on('click.a keyup.a', function() {
-            $(this).off('click.a keyup.a').select();
-          });
-        });
+        moment.locale(navigator.userLanguage || navigator.language || 'en-US');
+        timestamp.text(postedDate.local().format('lll'));
       });
     },
   });

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -515,12 +515,22 @@ form.like {
   padding:5px;
 }
 
-.share-link,
-.embed-src {
-  width:15em;
-  display:none;
+.share-container {
+  display: none;
   position: absolute;
   top: 2em;
+  background: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  padding: 1em;
+  z-index: 100;
+}
+
+.share-container ul {
+  list-style-type: none;
+}
+
+.share-container li {
+  text-align: right;
 }
 
 .dweet-timestamp{

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -24,7 +24,6 @@
       <a class="dweet-option embed-dwitter-link"  href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">full version</a>
       {% endif %}
       <a class="dweet-option share-button" href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">share</a>
-      <a class="dweet-option embed-button" href="" target="_blank">embed</a>
       {% if request.user == dweet.author or request.user.is_staff %}
         <form class="dweet-delete-form" action="{% url 'dweet_delete' dweet_id=dweet.id %}" method="post"
           onsubmit="return confirm('Are you sure you want to delete the dweet (cannot be reversed)?');" >
@@ -36,8 +35,18 @@
         </form>
       {% endif %}
       <a class="dweet-option fullscreen-button" href="javascript:;" target="_blank">fullscreen</a>
-      <input type=text readonly class=share-link value='{% url 'dweet_show' dweet_id=dweet.id %}'/>
-      <input type=text readonly class=embed-src value='<iframe width=500 height=570 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}" allowFullScreen="true"></iframe>'/>
+      <div class="share-container">
+        <ul>
+          <li>
+            <label>Permalink:</label>
+            <input type=text readonly class=share-link value='{% url 'dweet_show' dweet_id=dweet.id %}'/>
+          </li>
+          <li>
+            <label>Embed:</label>
+            <input type=text readonly class=embed-src value='<iframe width=500 height=570 frameBorder="0" src="{% url 'dweet_embed' dweet_id=dweet.id %}" allowFullScreen="true"></iframe>'/>
+          </li>
+        </ul>
+      </div>
     </div>
     <div class=author-remix-wrapper>
       <div class=dweet-author>


### PR DESCRIPTION
This creates a new, slightly nicer looking, popover that contains both
the share URL and an embed code. The plan is to re-use this popover
style for more types of content on the dweet card.

When I previously did this in f73d5b0 I was not aware that the code used
for lazy-loaded dweets was completely separate in another js file.
So this time, I delete the duplicated code in scrolling.js and instead
implement it one way by binding event listeners once on body instead of
separately per dweet card. This is also better for performance when
having lots of dweets loaded.


<img width="622" alt="screenshot 2018-03-31 18 12 16" src="https://user-images.githubusercontent.com/1413267/38165175-a6d37302-350f-11e8-9fe9-e74d106a40fd.png">

This fixes #310