### PR TITLE
Restore the href on the share-button

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Inspired by [arkt.is/t/](http://arkt.is/t/Yy53aWR0aD0yZTM7eC5maWxsUmVjdCgxNTAsMT
 * `make` (install dependencies and set up database)
 * `python manage.py createsuperuser` (create admin account used below)
 * `make run` runs the server. Use `make serve` instead if you're working inside a VM with port forwarding. (0.0.0.0:8000)
-* go to [http://localhost:8000/admin/sites/](http://localhost:8000/admin/sites/), login with admin account created above, click on the one entry, and change both `domain name` and `display name` to localhost:8000.
+* Go to [http://localhost:8000/admin/sites/](http://localhost:8000/admin/sites/) and log in with admin account created above.
+* Click on the one entry, and change both `domain name` and `display name` to localhost:8000.
 * Make sure http://dweet.localhost:8000/ returns a django error. May not work in Firefox.
 
 ## Other commands

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -23,7 +23,7 @@
       {% if embed %}
       <a class="dweet-option embed-dwitter-link"  href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">full version</a>
       {% endif %}
-      <a class="dweet-option share-button" href="" data-popover=".share-container">share</a>
+      <a class="dweet-option share-button" href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank" data-popover=".share-container">share</a>
       {% if dweet.dweet_set.count > 0 %}
       <a class="dweet-option remixes-button" href="" data-popover=".remixes-container">remixes</a>
       {% endif %}


### PR DESCRIPTION
Closes #317 

I see Stian is still using `e.preventDefault()` in https://github.com/lionleaf/dwitter/pull/314, so I hope this href won't break the popover. But it will be about 8 hours before I can get home and test that...!