### PR TITLE
Prevent XSS in the comment section

### DIFF
--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -115,7 +115,7 @@
     <ul class=sticky-comments>
       <li class="comment sticky-comment">
         <a class="comment-name sticky-comment" href="{% url 'user_feed' url_username=dweet.comments.last.author.username %}">{{ dweet.comments.last.author.username }}:</a>
-        <span class="comment-message sticky-comment">{{ dweet.comments.last.text | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
+        <span class="comment-message sticky-comment">{{ dweet.comments.last.text | force_escape | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
       </li>
       </ul>
         {% endif %}
@@ -135,7 +135,7 @@
       {% if comment != dweet.comments.last or dweet.comments.last.author != dweet.author  %}
       <li class=comment>
       <a class=comment-name href="{% url 'user_feed' url_username=comment.author.username %}">{{ comment.author.username }}:</a>
-      <span class="comment-message">{{ comment.text | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
+      <span class="comment-message">{{ comment.text | force_escape | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
       </li>
       {% endif %}
       {% endfor %}


### PR DESCRIPTION
This patch fixes the XSS vulnerability in the comment section.

### Problem

Because `insert_code_blocks()` marks the input text as "safe",it is
required to escape the text manually before passing to the filter.
Right now, we don't do so.

This results in allowing users to execute arbitrary JavaScript code
through malformed comments (like `<script>alert(3)</script>`)

### Solution

This patch fixes the issue by applying `force_escape()` before
`insert_code_blocks()`.