### PR TITLE
Remove unused share-button class to un-fool the ad-blockers

### DIFF
--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -23,7 +23,7 @@
       {% if embed %}
       <a class="dweet-option embed-dwitter-link"  href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">full version</a>
       {% endif %}
-      <a class="dweet-option share-button" href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank" data-popover=".share-container">share</a>
+      <a class="dweet-option" href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank" data-popover=".share-container">share</a>
       {% if dweet.dweet_set.count > 0 %}
       <a class="dweet-option remixes-button" href="" data-popover=".remixes-container">{{ dweet.dweet_set.count }} remix{% if dweet.dweet_set.count > 1 %}es{% endif %}</a>
       {% endif %}


### PR DESCRIPTION
As noted in #236 this class is invoking the wrath of some ad-blocker lists, and we're not currently using it anyway