### PR TITLE
Give dweet pages titles (either dweet ID or author's comment)

### DIFF
--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -2,7 +2,21 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>{% block title %} Dwitter {% endblock %} </title>
+    <title> {% block title %}
+      {% if dweet %}
+        {% if dweet.comments.last.author == dweet.author %}
+          {% with dweet.comments.last.text as author_comment %}
+            {# TODO: Djangify this: (author_comment[:37] + '...') if len(author_comment) > 40 else author_comment #}
+            {{ author_comment }}
+          {% endwith %}
+        {% else %}
+          d/{{ dweet.id }}
+        {% endif %}
+        by {{ dweet.author.username }} - Dwitter
+      {% else %}
+        Dwitter
+      {% endif %}
+    {% endblock %} </title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% load compress %}
 

--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -2,21 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title> {% block title %}
-      {% if dweet %}
-        {% if dweet.comments.last.author == dweet.author %}
-          {% with dweet.comments.last.text as author_comment %}
-            {# TODO: Djangify this: (author_comment[:37] + '...') if len(author_comment) > 40 else author_comment #}
-            {{ author_comment }}
-          {% endwith %}
-        {% else %}
-          d/{{ dweet.id }}
-        {% endif %}
-        by {{ dweet.author.username }} - Dwitter
-      {% else %}
-        Dwitter
-      {% endif %}
-    {% endblock %} </title>
+    <title>{% block title %} Dwitter {% endblock %} </title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% load compress %}
 

--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -14,6 +14,18 @@
 {% endcompress %}
 {% endblock %}
 
+{% block title %}
+  {% if dweet.comments.last.author == dweet.author %}
+    {% with dweet.comments.last.text as author_comment %}
+      {# TODO: Djangify this: (author_comment[:37] + '...') if len(author_comment) > 40 else author_comment #}
+      {{ author_comment }}
+    {% endwith %}
+  {% else %}
+    d/{{ dweet.id }}
+  {% endif %}
+  by {{ dweet.author.username }} - Dwitter
+{% endblock %}
+
 {% block body_class %}{{sort}}{% endblock %}
 
 

--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -18,11 +18,8 @@
   {% if dweet.deleted %}
     Deleted dweet - Dwitter
   {% else %}
-    {% if dweet.comments.last.author == dweet.author %}
-      {% with dweet.comments.last.text as author_comment %}
-        {# TODO: Djangify this: (author_comment[:37] + '...') if len(author_comment) > 40 else author_comment #}
-        {{ author_comment }}
-      {% endwith %}
+    {% if dweet.comments.last.author == dweet.author and not dweet.comments.last.text.41 %}
+      {{ dweet.comments.last.text }}
     {% else %}
       d/{{ dweet.id }}
     {% endif %}

--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -18,8 +18,8 @@
   {% if dweet.deleted %}
     Deleted dweet - Dwitter
   {% else %}
-    {% if dweet.comments.last.author == dweet.author and not dweet.comments.last.text.41 %}
-      {{ dweet.comments.last.text }}
+    {% if dweet.comments.last.author == dweet.author %}
+      {{ dweet.comments.last.text | truncatechars:40 }}
     {% else %}
       d/{{ dweet.id }}
     {% endif %}

--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -15,15 +15,19 @@
 {% endblock %}
 
 {% block title %}
-  {% if dweet.comments.last.author == dweet.author %}
-    {% with dweet.comments.last.text as author_comment %}
-      {# TODO: Djangify this: (author_comment[:37] + '...') if len(author_comment) > 40 else author_comment #}
-      {{ author_comment }}
-    {% endwith %}
+  {% if dweet.deleted %}
+    Deleted dweet - Dwitter
   {% else %}
-    d/{{ dweet.id }}
+    {% if dweet.comments.last.author == dweet.author %}
+      {% with dweet.comments.last.text as author_comment %}
+        {# TODO: Djangify this: (author_comment[:37] + '...') if len(author_comment) > 40 else author_comment #}
+        {{ author_comment }}
+      {% endwith %}
+    {% else %}
+      d/{{ dweet.id }}
+    {% endif %}
+    by {{ dweet.author.username }} - Dwitter
   {% endif %}
-  by {{ dweet.author.username }} - Dwitter
 {% endblock %}
 
 {% block body_class %}{{sort}}{% endblock %}


### PR DESCRIPTION
### What it do?

It gives semantic titles to the individual dweet pages. This will be good for bookmarking, and for search engine indexing.

### Requests for assistance

1. Do we need to escape the comment string before we put it in the HTML, or does Django do that for us?
2. ~I wanted to truncate the title to a maximum length of 40, but couldn't figure out the Django syntax (see comment in code)~
3. ***Done:*** Or we could simply ignore comments which are longer than 40 chars, and assume they aren't title-worthy.
4. The nested if-blocks barf a lot of spaces into the rendered HTML output. Perhaps this new titling code should move into a Python function somewhere.
5. (Future) Do you want to add "(138 chars)" at the end of the title?
6. (Future) If the dweet author has not left a comment, should we take the first comment and use that? ([example](https://www.dwitter.net/d/6473))
7. (Future) We could add titles for some of the other routes too, e.g. "Top feed - Dwitter" and "magna's awesomed dweets - Dwitter"

### Screenshots (check the window titles)

If the dweet author has made a comment which is 40 chars or less, that comment becomes the page title:

![joey s desktop on tomato at 7 04 52 pm on saturday 14 april 2018](https://user-images.githubusercontent.com/911799/38767611-1e0b3fa6-4017-11e8-86c8-2a8c36906f0b.png)

Otherwise the dweet ID is used in the page title:

![joey s desktop on tomato at 7 05 04 pm on saturday 14 april 2018](https://user-images.githubusercontent.com/911799/38767613-1e3fd536-4017-11e8-9701-a9cf165810db.png)

Thanks to prplz for some guidance and improvements