### PR TITLE
Disallow hashtags that start with a number and add tests

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -126,8 +126,10 @@ def view_hashtag(request, page_nr, hashtag_name):
         last = dweet_count
 
     dweet_list = hashtag.dweets.annotate(num_likes=Count('likes')).order_by('-posted')[first:last]
-    next_url = reverse('view_hashtag_page', kwargs={'hashtag_name': hashtag_name, 'page_nr': page + 1})
-    prev_url = reverse('view_hashtag_page', kwargs={'hashtag_name': hashtag_name, 'page_nr': page - 1})
+    next_url = reverse('view_hashtag_page',
+                       kwargs={'hashtag_name': hashtag_name, 'page_nr': page + 1})
+    prev_url = reverse('view_hashtag_page',
+                       kwargs={'hashtag_name': hashtag_name, 'page_nr': page - 1})
 
     dweet_list = list(
         dweet_list

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -74,7 +74,7 @@ class Comment(models.Model):
 # Should be idempotent.
 @receiver(post_save, sender=Comment, dispatch_uid="add_hashtags_from_comment")
 def add_hashtags(sender, instance, **kwargs):
-    hash_pattern = re.compile(r'#(?P<hashtag>[_a-zA-Z\d]+)')
+    hash_pattern = re.compile(r'#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)')
     for hashtag in re.findall(hash_pattern, instance.text):
         h = Hashtag.objects.get_or_create(name=hashtag.lower())[0]
         if not h.dweets.filter(id=instance.reply_to.id).exists():

--- a/dwitter/templatetags/insert_magic_links.py
+++ b/dwitter/templatetags/insert_magic_links.py
@@ -44,9 +44,8 @@ def insert_magic_links(text):
     )
     text = re.sub(
         r'(?P<text>'                                            # capture original pattern
-        r'#(?P<hashtag>[_a-zA-Z\d]+)[^_a-zA-Z\d]?)',              # hashtag
+        r'#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)[^_a-zA-Z\d]?)',   # hashtag
         hashtag_to_link,
         text
     )
-
     return text

--- a/dwitter/tests/models/test_hashtags.py
+++ b/dwitter/tests/models/test_hashtags.py
@@ -24,22 +24,38 @@ class HashtagTestCase(TestCase):
                                            author=self.user2)
 
         Comment.objects.create(id=1,
-                               text="comment1 text with #hashtag #2hash",
+                               text="comment1 text with #hashtag #hash2 #2hash",
                                posted=now - timedelta(minutes=1),
                                reply_to=self.dweet2,
                                author=user1)
 
         Comment.objects.create(id=2,
-                               text="comment2 text #hashtag #1hash",
+                               text="comment2 text #hashtag #1hash #hash1",
                                posted=now,
                                reply_to=self.dweet1,
                                author=self.user2)
 
     def test_hashtags_created(self):
         h = Hashtag.objects.get(name='hashtag')
-        h1 = Hashtag.objects.get(name='1hash')
-        h2 = Hashtag.objects.get(name='2hash')
+
+        h1 = Hashtag.objects.get(name='hash1')
+        h2 = Hashtag.objects.get(name='hash2')
+
+        try:
+            illegal1 = Hashtag.objects.get(name='1hash')
+            self.assertEqual(illegal1, True)  # should throw an exception!
+        except:
+            pass
+
+        try:
+            illegal2 = Hashtag.objects.get(name='2hash')
+            self.assertEqual(illegal2, True)  # should throw an exception!
+        except:
+            pass
+
         self.assertEqual(h is None, False)
+        self.assertEqual(h1 is None, False)
+        self.assertEqual(h2 is None, False)
         self.assertEqual(h.dweets.count(), 2)
         self.assertEqual(h1.dweets.all()[0], self.dweet1)
         self.assertEqual(h2.dweets.all()[0], self.dweet2)
@@ -53,27 +69,32 @@ class HashtagTestCase(TestCase):
         self.dweet3.save()
 
         c = Comment(id=3,
-                    text="comment3 text #hashtag #3_hash",
+                    text="comment3 text #hashtag #h_3 #_3",
                     posted=timezone.now(),
                     reply_to=self.dweet3,
                     author=self.user2)
         c.save()
 
         h = Hashtag.objects.get(name='hashtag')
-        h3 = Hashtag.objects.get(name='3_hash')
+        h3 = Hashtag.objects.get(name='h_3')
+        h_3 = Hashtag.objects.get(name='_3')
+        self.assertEqual(h is None, False)
+        self.assertEqual(h3 is None, False)
+        self.assertEqual(h_3 is None, False)
         self.assertEqual(h.dweets.count(), 3)
         self.assertEqual(h.dweets.get(id=3), self.dweet3)
         self.assertEqual(h3.dweets.all()[0], self.dweet3)
+        self.assertEqual(h_3.dweets.all()[0], self.dweet3)
 
     def test_no_double_adding(self):
         # add #hashtag and #1hash to dweet1 again and see that the size
         # of those hashtags doesn't change
         Comment.objects.create(id=4,
-                               text="comment2 text #hashtag #1hash",
+                               text="comment2 text #hashtag #hash1",
                                posted=timezone.now(),
                                reply_to=self.dweet1,
                                author=self.user2)
         h = Hashtag.objects.get(name='hashtag')
-        h1 = Hashtag.objects.get(name='1hash')
+        h1 = Hashtag.objects.get(name='hash1')
         self.assertEqual(h.dweets.count(), 2)
         self.assertEqual(h1.dweets.count(), 1)

--- a/dwitter/tests/templatetags/test_insert_magic_links.py
+++ b/dwitter/tests/templatetags/test_insert_magic_links.py
@@ -169,6 +169,26 @@ class DweetTestCase(TestCase):
             insert_magic_links('Dwitter is just #amaze-balls, right?')
         )
 
+    def test_insert_magic_hashtag_not_start_with_digit(self):
+        self.assertEqual(
+            'Dwitter is just #1337 or <a href="/h/super1337">#super1337</a>?',
+            insert_magic_links('Dwitter is just #1337 or #super1337?')
+        )
+
+    def test_insert_magic_single_character_hashtag(self):
+        self.assertEqual(
+            '<a href="/h/s">#s</a>',
+            insert_magic_links('#s')
+        )
+        self.assertEqual(
+            '<a href="/h/S">#S</a>',
+            insert_magic_links('#S')
+        )
+        self.assertEqual(
+            '#1',  # Start with digit not legal
+            insert_magic_links('#1')
+        )
+
     # mixed
 
     def test_insert_magic_links_mixed(self):


### PR DESCRIPTION
For instance ' escapes to &#32; which would be a valid hashtag with
the previous hashtag rules. This commits makes any hashtag starting
with a number illegal, as is common other places.

Also adds some tests to verify