### PR TITLE
Removed direct link to "register" for better mobile flow

### DIFF
--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -89,8 +89,6 @@
           </ul>
           {% else %}
           <a href="{% url 'auth_login'  %}" > Login </a>
-          or
-          <a href="{% url 'register'  %}" > register </a>
           {% endif %}
         </div>
 


### PR DESCRIPTION
By removing the register link from the header, it will be slimmer on
mobile. There is a register link on the login page.

Before
------------------
<img width="407" alt="screen shot 2018-04-29 at 3 07 47 pm" src="https://user-images.githubusercontent.com/610925/39407657-30f5ee8a-4bc1-11e8-938b-c1939e9fa667.png">




After
------------------
<img width="390" alt="screen shot 2018-04-29 at 3 07 26 pm" src="https://user-images.githubusercontent.com/610925/39407658-337e3c66-4bc1-11e8-9157-5cb931f63176.png">



