### PR TITLE
Make the permalink just wide enough to show the entire link

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -580,6 +580,11 @@ form.like {
   text-align: right;
 }
 
+.share-container input {
+  /* Wide enough so that a five digit dweet ID displays fully, with a small gap left over */
+  width: 15.5em;
+}
+
 .remixes-container li {
   padding: 5px 0;
 }


### PR DESCRIPTION
Before:
> ![joey s google-chrome at 10 40 23 pm on sunday 6 may 2018](https://user-images.githubusercontent.com/911799/39674614-0b376906-5181-11e8-9c06-dee1b70015ce.png)

:fire: :rage: :gun: :ambulance: :bed: :cry:

After:
> ![joey s google-chrome at 10 55 01 pm on sunday 6 may 2018](https://user-images.githubusercontent.com/911799/39674615-0b69881e-5181-11e8-997f-d7311fa5f747.png)

:ok_hand: :dove: :heart: :rainbow: :deciduous_tree: :balloon: