### PR TITLE
Add 'about' link to the header area of permalink.html

### DIFF
--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -40,6 +40,7 @@
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
   <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
   <li><a class="random" href="{% url 'random_feed' %}">random</a></li>
+  <li><a class="about" href="{% url 'about' %}">about</a></li>
 </ul>
 {% endblock %}
 


### PR DESCRIPTION
This patch adds a link to 'dwitter.net/about' on the permalink page,
which has been missing for no good reason.

(This issue was reported by Dwitterer on discord)

**Before**

![2018-05-07-000817_457x123_scrot](https://user-images.githubusercontent.com/8974561/39674695-c4d4aba4-518a-11e8-8d8f-05b6ece78ee9.png)

**After**

![2018-05-07-000739_476x131_scrot](https://user-images.githubusercontent.com/8974561/39674699-d6ae1f40-518a-11e8-9104-1d22fe9d4c76.png)
