### PR TITLE
Hide/show the header when scrolling down/up on low res devices

### DIFF
--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -177,3 +177,32 @@ function registerStatsClickListeners(element) {
     hideStats(element, iframe);
   });
 }
+
+// Show/hide header when scrolling
+(function() {
+  // One user scroll action can fire many browser 'scroll' events, so for efficiency we avoid DOM
+  // interactions by keeping the current state in a boolean
+  var isHidden = false;
+  var lastScrollTop = null;
+  window.addEventListener('scroll', function() {
+    var newScrollTop = $(this).scrollTop();
+    var header = $('.head-menu');
+    var newHiddenState = isHidden;
+    // Ignore scroll event when page is first loaded
+    if (lastScrollTop != null) {
+      // Do not scroll the header away immedately at the top of the page; that would look empty
+      // because there is nothing behind it!  (This value is #content padding-top minus 5)
+      if (newScrollTop > lastScrollTop && newScrollTop > 85) {
+        newHiddenState = true;
+      }
+      if (newScrollTop < lastScrollTop) {
+        newHiddenState = false;
+      }
+      if (newHiddenState !== isHidden) {
+        isHidden = newHiddenState;
+        header.toggleClass('hidden', isHidden);
+      }
+    }
+    lastScrollTop = newScrollTop;
+  });
+}());

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -346,6 +346,19 @@ iframe {
   padding-left: 1em;
 }
 
+/* Enable hide/show styles for the header when scrolling, but only at low res. */
+/* A dweet canvas never grows taller than 320px, so after 420px both canvas and header can fit on screen. */
+@media (max-height: 420px) {
+  .head-menu {
+    top: 0;
+    transition: top 0.3s ease-out;
+  }
+  .head-menu.hidden {
+    top: -150px;
+    transition: top 0.3s ease-out;
+  }
+}
+
 .next-page {
   display:none;
 }


### PR DESCRIPTION
## What it do

On low-height windows, it will hide the header when scrolling down, and show it again when scrolling up.

The goal:

> It should be possible to see an entire dweet's canvas on the screen, without having to go fullscreen.
> If the header is going to obscure the canvas, then we need to hide it somehow.

Commonly in CSS people write `@media (max-width: foo)` but this feature is relevant to height so I used `max-height`.

Since the dweet canvas never grows taller than 320px, and the header is usually 91px or less, the feature disables itself when the device height is greater than 420px.

At lower widths the canvas shrinks below 320px, but I didn't feel brave enough to [use `calc()` in the media query](https://stackoverflow.com/questions/23667208/calc-not-working-within-media-queries).

(So the current rule might produce some false positives at low res portrait, e.g. on a 200x400 display, the header will be hidden, even though the canvas won't be anywhere near 320px tall, so in fact it could be shown.  But at least it shouldn't fail to trigger when it's needed, i.e. no false negatives.  At 320x480 the header does grow to 130px on my test site, but the canvas is so small there is no danger of overlap.  Could perhaps test that with a busier header, e.g. on `/u/a_really_really.really.really.long_name`...)

## Concerns

1. Should the goal be more ambitious?  Should we aim to

    > show the entire canvas *and* (if in portrait orientation) the code editing area too?

    (My philosophy with this PR is that people don't usually edit code on small devices, so we don't urgently need to make that experience smooth.  But if we did want to do it, it might not be difficult or painful.  I haven't thought about it yet.  It might just mean a slightly larger max-height.)

2. Should we use [`document.documentElement.scrollTop`](https://stackoverflow.com/questions/3464876/javascript-get-window-x-y-position-for-scroll) instead of `$(window).scrollTop()`, for efficiency?  I used jQuery because I am confident it works cross-browser.

3. Some sites only bring back the header after the user has scrolled up 5 pixels.  Should we do that too?  The code in this PR is very sensitive, requiring only 1 pixel movement to trigger.

I shouldn't write all this blah blah, it probably only scares people.  Please just give this code a little test and approve it if you're happy.  ;-)