### PR TITLE
Hide/show header so that entire dweet box is visible

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -347,8 +347,9 @@ iframe {
 }
 
 /* Enable hide/show styles for the header when scrolling, but only at low res. */
-/* A dweet canvas never grows taller than 320px, so after 420px both canvas and header can fit on screen. */
-@media (max-height: 420px) {
+/* A dweet canvas never grows taller than 320px, so after 420px both canvas and bloated header can fit on screen. */
+/* But if we want to accomodate the entire dweet box that's 572px max box height + 56px for small header - margins = 620px */
+@media (max-height: 620px) {
   .head-menu {
     top: 0;
     transition: top 0.3s ease-out;


### PR DESCRIPTION
Lionleaf suggested increasing the height below which header hiding would activate. What a nutter!

Adding an extra 200 pixels should now allow devices to view the entire dweet box (if they can) before the header will transition to a fixed state of being.

If you want a slow rollout of this feature, maybe hold back on this PR until all users providing negative feedback have been suitably dealt with.