### PR TITLE
Use css transforms for header animation

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -351,12 +351,12 @@ iframe {
 /* But if we want to accomodate the entire dweet box that's 572px max box height + 56px for small header - margins = 620px */
 @media (max-height: 620px) {
   .head-menu {
-    top: 0;
-    transition: top 0.3s ease-out;
+    transform: translateY(0);
+    transition: transform 0.3s ease-out;
   }
   .head-menu.hidden {
-    top: -150px;
-    transition: top 0.3s ease-out;
+    transform: translateY(-150px);
+    transition: transform 0.3s ease-out;
   }
 }
 


### PR DESCRIPTION
This improves the performance of the animation, because animating the
transform property is much faster than animating the top property. The
top property triggers expensive layout calculations every time it
changes, while the transform property has been specifically optimized
for fast animations. This should ensure that the header on mobile
scrolls smoothly in and out of view.

https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/