### PR TITLE
Fix remixes not enforcing 140 char rule

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -205,8 +205,13 @@ def dweet(request):
 
 @login_required
 def dweet_reply(request, dweet_id):
+    code = request.POST['code']
+
+    if(len(code.replace('\r\n', '\n')) > 140):
+        return HttpResponseBadRequest("Dweet code too long! Code: " + code)
+
     reply_to = get_object_or_404(Dweet, id=dweet_id)
-    d = Dweet(code=request.POST['code'],
+    d = Dweet(code=code,
               reply_to=reply_to,
               author=request.user,
               posted=timezone.now())


### PR DESCRIPTION
As a matter of fact I was able to bypass the 140 characters limit. This is because reply/remix API does not enforce the 140 character limit rule, unlike the one responsible for creating dweets from scratch. This was fixed by copying and pasting the preceding code.

PoC: https://www.dwitter.net/d/8555 (no hard feelings if deleted)