### PR TITLE
Clear all newly added globals when dweet resets

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -19,6 +19,7 @@
       var lastError = "";
       var playing = !!autoplay;
       var FPS = 60;
+      var pauseTime = null;
       
       var recording = false;
       var encoder;

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -264,7 +264,9 @@
     function reset(){
       Object.keys(window).forEach(key => {
         if (!browserGlobals[key]) {
-          // console.log("Removing new global: " + key);
+          if (window.debug) {
+            console.log("Removing new global: " + key);
+          }
           delete window[key];
         }
       });

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -185,7 +185,10 @@
 
     // Remember the default globals so that later we can remove any that
     // were created by the dweet
-    var browserGlobals = Object.keys(window);
+    var browserGlobals = {};
+    Object.keys(window).forEach(key => {
+      browserGlobals[key] = true;
+    });
 
     var c = document.querySelector("#c");
     c.width = 1920;
@@ -260,7 +263,7 @@
 
     function reset(){
       Object.keys(window).forEach(key => {
-        if (!browserGlobals.includes(key)) {
+        if (!browserGlobals[key]) {
           // console.log("Removing new global: " + key);
           delete window[key];
         }

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -181,7 +181,11 @@
 
     var stats = createStats();
     setStatsVisibility({{ newDweet }});
-  
+
+    // Remember the default globals so that later we can remove any that
+    // were created by the dweet
+    var browserGlobals = Object.keys(window);
+
     var c = document.querySelector("#c");
     c.width = 1920;
     c.height = 1080;
@@ -254,6 +258,12 @@
     }
 
     function reset(){
+      Object.keys(window).forEach(key => {
+        if (!browserGlobals.includes(key)) {
+          // console.log("Removing new global: " + key);
+          delete window[key];
+        }
+      });
       c = document.querySelector("#c");
       c.width = 1920;
       c.height = 1080;


### PR DESCRIPTION
An implementation of [Magna's suggestion](https://github.com/lionleaf/dwitter/issues/93#issuecomment-401560322)

I gave it a little test (with the console log uncommented):

![joey s google-chrome at 4 11 04 pm on sunday 1 july 2018](https://user-images.githubusercontent.com/911799/42132386-6a3bced0-7d49-11e8-9757-6949a3051303.png)

It seems to have detected a var `pauseTime` which we forgot to declare in the dwitter code. So I added a declaration for that too.

This code makes use of `Array.prototype.includes` which is [not supported in IE11](https://caniuse.com/#feat=array-includes). I could fix that if we want to support IE11.