### PR TITLE
[experiment] Make the animation loop use local vars, not globals

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -14,154 +14,6 @@
       }
     </style>
   <script type="text/javascript" src="/static/libs/gif.js"></script>
-    <script>
-      var autoplay = getURLParameter('autoplay');
-      var lastError = "";
-      var playing = !!autoplay;
-      var FPS = 60;
-      
-      var recording = false;
-      var encoder;
-      var gifCanvas = document.createElement("canvas");
-      var gifctx;
-      var dweetId;
-	  var username;
-      var minGIFWidth = 640;
-    
-      function receiveMessage(event){
-        var origin = event.origin || event.originalEvent.origin;
-        console.log("Received message from " + origin);
-        if(origin !== "http://dwitter.localhost:8000"
-          && origin !== "http://localhost:8000"
-          && origin !== "https://localhost:8000"
-          && origin !== "https://www.dwitter.net"
-          && origin !== "https://dwitter.net"){
-            return;
-          }
-        console.log("Message was: " + event.data);
-
-        switch (event.data) {
-          case "toggle":
-            playing ? pauseDemo() : playDemo();
-            break;
-          case "play":
-            playDemo();
-            break;
-          case "pause":
-            pauseDemo();
-            break;
-          case "showStats":
-            setStatsVisibility(true);
-            break;
-          case "hideStats":
-            setStatsVisibility(false);
-            break;
-          case "stopGifRecord":
-            if (recording) {
-            recording = false;
-            encoder.render();
-            encoder.on("finished", function (blob) {
-              let a = document.createElement("a");
-              document.body.appendChild(a);
-              a.style.display = "none";
-              a.href = URL.createObjectURL(blob);
-              a.download = "dweet.gif";
-              a.click();
-              document.body.removeChild(a);
-              URL.revokeObjectURL(a.href);
-              window.top.postMessage({ msg: "finished", dweetId: dweetId }, "*");
-            });
-            time = 0;
-            frame = 0;
-            break;
-          }
-        }
-
-        if (event.data.msg == "startGifRecord") {
-          if (!recording) {
-            dweetId = event.data.dweetId;
-			username = event.data.username;
-          
-            recording = true;
-            var workerCount = 4;
-            var width = Math.max(c.width, minGIFWidth);
-            if (typeof navigator.hardwareConcurrency !== "undefined")
-              workerCount = navigator.hardwareConcurrency;
-            encoder = new GIF({ 
-              workers: workerCount, 
-              quality: 5, 
-              workerScript: "/static/libs/gif.worker.js",
-              width: width, 
-              height: width / 16 * 9,
-              background: ""
-            });
-            gifCanvas.width = width;
-            gifCanvas.height = width / 16 * 9;
-            gifctx = gifCanvas.getContext("2d");
-            time = 0;
-            frame = 0;
-          }
-        } else if (event.data.substring(0, 4) == "code"){
-          var code = event.data.substring(5,event.data.length);
-          newCode(code);
-        }
-      }
-
-      function displayError(e) {
-        if(lastError != e){
-          lastError = e;
-          parent.postMessage({
-            'type': 'error',
-            'error': ""+e,
-            'location': window.location.href
-          },"*");
-        }
-      }
-
-      function newCode(code) {
-          try {
-            eval("function u(t) {\n"+code+"\n}");
-            window.u = u;
-          } catch (e) {
-            window.u = function(t) {
-              throw e;
-            };
-            throw e;
-          }
-          displayError("");
-          reset();
-      }
-
-      function pauseDemo(){
-        if(!playing){
-          return;
-        }
-
-        pauseTime = +new Date();
-
-        playing = false;
-      }
-
-      function playDemo(){
-        if(playing){
-          return
-        }
-
-        playing = true;
-        requestAnimationFrame(loop);
-      }
-      var timeOffset = 0;
-
-      addEventListener("message", receiveMessage, false);
-
-      function getURLParameter(name) {
-        return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null
-      }
-
-      function setStatsVisibility(visible) {
-        document.getElementById('stats').style.visibility = visible ? 'visible' : 'hidden';
-      }
-    </script>
     {% load compress %}
     {% load staticfiles %}
     {% compress js %}
@@ -171,6 +23,154 @@
 <body>
   <canvas id=c></canvas>
   <script>
+  (function() {
+    var autoplay = getURLParameter('autoplay');
+    var lastError = "";
+    var playing = !!autoplay;
+    var FPS = 60;
+
+    var recording = false;
+    var encoder;
+    var gifCanvas = document.createElement("canvas");
+    var gifctx;
+    var dweetId;
+    var username;
+    var minGIFWidth = 640;
+
+    function receiveMessage(event){
+      var origin = event.origin || event.originalEvent.origin;
+      console.log("Received message from " + origin);
+      if(origin !== "http://dwitter.localhost:8000"
+        && origin !== "http://localhost:8000"
+        && origin !== "https://localhost:8000"
+        && origin !== "https://www.dwitter.net"
+        && origin !== "https://dwitter.net"){
+          return;
+        }
+      console.log("Message was: " + event.data);
+
+      switch (event.data) {
+        case "toggle":
+          playing ? pauseDemo() : playDemo();
+          break;
+        case "play":
+          playDemo();
+          break;
+        case "pause":
+          pauseDemo();
+          break;
+        case "showStats":
+          setStatsVisibility(true);
+          break;
+        case "hideStats":
+          setStatsVisibility(false);
+          break;
+        case "stopGifRecord":
+          if (recording) {
+          recording = false;
+          encoder.render();
+          encoder.on("finished", function (blob) {
+            let a = document.createElement("a");
+            document.body.appendChild(a);
+            a.style.display = "none";
+            a.href = URL.createObjectURL(blob);
+            a.download = "dweet.gif";
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(a.href);
+            window.top.postMessage({ msg: "finished", dweetId: dweetId }, "*");
+          });
+          time = 0;
+          frame = 0;
+          break;
+        }
+      }
+
+      if (event.data.msg == "startGifRecord") {
+        if (!recording) {
+          dweetId = event.data.dweetId;
+          username = event.data.username;
+
+          recording = true;
+          var workerCount = 4;
+          var width = Math.max(c.width, minGIFWidth);
+          if (typeof navigator.hardwareConcurrency !== "undefined")
+            workerCount = navigator.hardwareConcurrency;
+          encoder = new GIF({ 
+            workers: workerCount, 
+            quality: 5, 
+            workerScript: "/static/libs/gif.worker.js",
+            width: width, 
+            height: width / 16 * 9,
+            background: ""
+          });
+          gifCanvas.width = width;
+          gifCanvas.height = width / 16 * 9;
+          gifctx = gifCanvas.getContext("2d");
+          time = 0;
+          frame = 0;
+        }
+      } else if (event.data.substring(0, 4) == "code"){
+        var code = event.data.substring(5,event.data.length);
+        newCode(code);
+      }
+    }
+
+    function displayError(e) {
+      if(lastError != e){
+        lastError = e;
+        parent.postMessage({
+          'type': 'error',
+          'error': ""+e,
+          'location': window.location.href
+        },"*");
+      }
+    }
+
+    function newCode(code) {
+        try {
+          eval("function u(t) {\n"+code+"\n}");
+          window.u = u;
+        } catch (e) {
+          window.u = function(t) {
+            throw e;
+          };
+          throw e;
+        }
+        displayError("");
+        reset();
+    }
+
+    function pauseDemo(){
+      if(!playing){
+        return;
+      }
+
+      pauseTime = +new Date();
+
+      playing = false;
+    }
+
+    function playDemo(){
+      if(playing){
+        return
+      }
+
+      playing = true;
+      requestAnimationFrame(loop);
+    }
+    var timeOffset = 0;
+
+    addEventListener("message", receiveMessage, false);
+
+    function getURLParameter(name) {
+      return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null
+    }
+
+    function setStatsVisibility(visible) {
+      document.getElementById('stats').style.visibility = visible ? 'visible' : 'hidden';
+    }
+
     function createStats() {
       var stats = new Stats();
       stats.showPanel(0);
@@ -268,6 +268,7 @@
       time = 0;
       frame = 0;
     }
-    </script>
+  }());
+  </script>
 
 </body>

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -45,8 +45,8 @@
         && origin !== "https://localhost:8000"
         && origin !== "https://www.dwitter.net"
         && origin !== "https://dwitter.net"){
-          return;
-        }
+        return;
+      }
       console.log("Message was: " + event.data);
 
       switch (event.data) {
@@ -67,23 +67,23 @@
           break;
         case "stopGifRecord":
           if (recording) {
-          recording = false;
-          encoder.render();
-          encoder.on("finished", function (blob) {
-            let a = document.createElement("a");
-            document.body.appendChild(a);
-            a.style.display = "none";
-            a.href = URL.createObjectURL(blob);
-            a.download = "dweet.gif";
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(a.href);
-            window.top.postMessage({ msg: "finished", dweetId: dweetId }, "*");
-          });
-          time = 0;
-          frame = 0;
-          break;
-        }
+            recording = false;
+            encoder.render();
+            encoder.on("finished", function (blob) {
+              let a = document.createElement("a");
+              document.body.appendChild(a);
+              a.style.display = "none";
+              a.href = URL.createObjectURL(blob);
+              a.download = "dweet.gif";
+              a.click();
+              document.body.removeChild(a);
+              URL.revokeObjectURL(a.href);
+              window.top.postMessage({ msg: "finished", dweetId: dweetId }, "*");
+            });
+            time = 0;
+            frame = 0;
+            break;
+          }
       }
 
       if (event.data.msg == "startGifRecord") {
@@ -128,17 +128,17 @@
     }
 
     function newCode(code) {
-        try {
-          eval("function u(t) {\n"+code+"\n}");
-          window.u = u;
-        } catch (e) {
-          window.u = function(t) {
-            throw e;
-          };
+      try {
+        eval("function u(t) {\n"+code+"\n}");
+        window.u = u;
+      } catch (e) {
+        window.u = function(t) {
           throw e;
-        }
-        displayError("");
-        reset();
+        };
+        throw e;
+      }
+      displayError("");
+      reset();
     }
 
     function pauseDemo(){
@@ -181,7 +181,7 @@
 
     var stats = createStats();
     setStatsVisibility({{ newDweet }});
-  
+
     var c = document.querySelector("#c");
     c.width = 1920;
     c.height = 1080;
@@ -217,28 +217,28 @@
         if (recording && frame % 2 == 0) {
           gifctx.fillStyle = "white";
           gifctx.fillRect(0, 0, gifCanvas.width, gifCanvas.height);
-          
+
           gifctx.drawImage(c, 0, 0, gifCanvas.width, gifCanvas.width / c.width * c.height);
-          
+
           gifctx.font = "20px sans-serif";
-          
+
           gifctx.strokeStyle = "white";
           gifctx.fillStyle = "black";
           gifctx.miterLimit = 2;
           gifctx.lineJoin = 'circle';
-          
+
           gifctx.lineWidth = 3;
           gifctx.strokeText("dwitter.net/d/" + dweetId, 3, gifCanvas.height - 16);
           gifctx.lineWidth = 1;
           gifctx.fillText("dwitter.net/d/" + dweetId, 3, gifCanvas.height - 16);
-		  
-		  var usernameWidth = gifctx.measureText("u/" + username).width;
-		  
-		  gifctx.lineWidth = 3;
+
+          var usernameWidth = gifctx.measureText("u/" + username).width;
+
+          gifctx.lineWidth = 3;
           gifctx.strokeText("u/" + username, gifCanvas.width - usernameWidth - 3, gifCanvas.height - 16);
           gifctx.lineWidth = 1;
           gifctx.fillText("u/" + username,  gifCanvas.width - usernameWidth - 3, gifCanvas.height - 16);
-          
+
           encoder.addFrame(gifctx, { copy: true, delay: 1000 / 30 });
         } 
         stats.end();
@@ -250,7 +250,7 @@
       }
     }
     if(autoplay) {
-        loop();
+      loop();
     }
 
     function reset(){

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -37,14 +37,14 @@
     var username;
     var minGIFWidth = 640;
 
-    function receiveMessage(event){
+    function receiveMessage(event) {
       var origin = event.origin || event.originalEvent.origin;
       console.log("Received message from " + origin);
-      if(origin !== "http://dwitter.localhost:8000"
-        && origin !== "http://localhost:8000"
-        && origin !== "https://localhost:8000"
-        && origin !== "https://www.dwitter.net"
-        && origin !== "https://dwitter.net"){
+      if (origin !== "http://dwitter.localhost:8000"
+          && origin !== "http://localhost:8000"
+          && origin !== "https://localhost:8000"
+          && origin !== "https://www.dwitter.net"
+          && origin !== "https://dwitter.net") {
         return;
       }
       console.log("Message was: " + event.data);
@@ -69,8 +69,8 @@
           if (recording) {
             recording = false;
             encoder.render();
-            encoder.on("finished", function (blob) {
-              let a = document.createElement("a");
+            encoder.on("finished", function(blob) {
+              var a = document.createElement("a");
               document.body.appendChild(a);
               a.style.display = "none";
               a.href = URL.createObjectURL(blob);
@@ -96,13 +96,13 @@
           var width = Math.max(c.width, minGIFWidth);
           if (typeof navigator.hardwareConcurrency !== "undefined")
             workerCount = navigator.hardwareConcurrency;
-          encoder = new GIF({ 
-            workers: workerCount, 
-            quality: 5, 
+          encoder = new GIF({
+            workers: workerCount,
+            quality: 5,
             workerScript: "/static/libs/gif.worker.js",
-            width: width, 
+            width: width,
             height: width / 16 * 9,
-            background: ""
+            background: "",
           });
           gifCanvas.width = width;
           gifCanvas.height = width / 16 * 9;
@@ -110,19 +110,19 @@
           time = 0;
           frame = 0;
         }
-      } else if (event.data.substring(0, 4) == "code"){
+      } else if (event.data.substring(0, 4) == "code") {
         var code = event.data.substring(5,event.data.length);
         newCode(code);
       }
     }
 
     function displayError(e) {
-      if(lastError != e){
+      if (lastError != e) {
         lastError = e;
         parent.postMessage({
           'type': 'error',
           'error': ""+e,
-          'location': window.location.href
+          'location': window.location.href,
         },"*");
       }
     }
@@ -141,8 +141,8 @@
       reset();
     }
 
-    function pauseDemo(){
-      if(!playing){
+    function pauseDemo() {
+      if (!playing) {
         return;
       }
 
@@ -151,8 +151,8 @@
       playing = false;
     }
 
-    function playDemo(){
-      if(playing){
+    function playDemo() {
+      if (playing) {
         return
       }
 
@@ -193,7 +193,7 @@
       a = a === undefined ? 1 : a;
       return "rgba("+(r|0)+","+(g|0)+","+(b|0)+","+a+")";
     }
-  
+
     var time = 0;
     var frame = 0;
     function u(t) {
@@ -202,11 +202,11 @@
     function loop() {
       stats = stats || createStats();
 
-      if (playing){
+      if (playing) {
         requestAnimationFrame(loop);
       }
       time = frame/FPS;
-      if(time * FPS | 0 == frame - 1){
+      if (time * FPS | 0 == frame - 1) {
         time += 0.000001;
       }
       frame++;
@@ -240,7 +240,7 @@
           gifctx.fillText("u/" + username,  gifCanvas.width - usernameWidth - 3, gifCanvas.height - 16);
 
           encoder.addFrame(gifctx, { copy: true, delay: 1000 / 30 });
-        } 
+        }
         stats.end();
         displayError("");
       } catch (e) {
@@ -249,11 +249,11 @@
         throw e;
       }
     }
-    if(autoplay) {
+    if (autoplay) {
       loop();
     }
 
-    function reset(){
+    function reset() {
       c = document.querySelector("#c");
       c.width = 1920;
       c.height = 1080;


### PR DESCRIPTION
Valentine and Keith Clark were wondering why arkt.is sometimes renders with a higher framerate than dwitter.

I thought it might be more efficient if, instead of global vars, all the vars referenced by the loop were enclosed inside a function scope.

That's what this PR does. It moves everything into one big IIFE. (It also does some code tidying, although those commits could easily be dropped.)

However my unconclusion from a couple of tests was entirely inconclusive about any improvement.

So you people are welcome to try this code out. But if no numbers are found to support any increase in efficiency, then I guess we can just **close this pull request**!  (Unless you decide you like it purely for aesthetic reasons.)

----

(There are other things we can experiment with, to try to match the same FPS as arkt.is...)

----

Edit: Oh boy, this is forked off a branch that is 10 weeks old too. :stuck_out_tongue: