### PR TITLE
Change 'infinite loop' timeout text

### DIFF
--- a/dwitter/static/libs/loopbuster.js
+++ b/dwitter/static/libs/loopbuster.js
@@ -44,7 +44,7 @@
             case "WhileStatement":
               var m = 1 + a.body.range[0],
                 h = a.body.range[1],
-                c = "window.stopper.restartLoop(%d);if (window.stopper.testLoop(%d)){throw 'Infinite loop!';}".replace(/%d/g, n),
+                c = "window.stopper.restartLoop(%d);if (window.stopper.testLoop(%d)){throw 'Frame timed out, paused dweet.';}".replace(/%d/g, n),
                 e = "";
               "BlockStatement" !== a.body.type && (c = "{" + c, e = "\n}", --m);
               l.push({


### PR DESCRIPTION
In some cases the "infinite loop" buster will stop dweets that are just too slow. 

And since we haven't solved the halting problem, clarify that the its a timeout exception.

Currently some dweets time out on my phone:
![screenshot_20180716-001427_chrome](https://user-images.githubusercontent.com/610925/42746804-84974124-888e-11e8-8810-4fbc98be0c62.jpg)


I'm merging this quickly as a hotfix before going to bed. But if someone can come up with a better text, please comment on this pull request or open an issue.