### PR TITLE
Browserglobals fix

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -28,7 +28,9 @@
       var dweetId;
       var username;
       var minGIFWidth = 640;
-    
+
+      var browserGlobals = {};
+
       function receiveMessage(event){
         var origin = event.origin || event.originalEvent.origin;
         console.log("Received message from " + origin);
@@ -179,6 +181,13 @@
     <script src="{% static "libs/loopbuster.js" %}"></script>
     <script src="{% static "libs/loopstopper.js" %}"></script>
     {% endcompress %}
+    <script>
+      // Remember the default globals so that later we can remove any that
+      // were created by the dweet
+      Object.keys(window).forEach(key => {
+        browserGlobals[key] = true;
+      });
+    </script>
   </head>
 <body>
   <canvas id=c></canvas>
@@ -193,13 +202,6 @@
 
     var stats = createStats();
     setStatsVisibility({{ newDweet }});
-
-    // Remember the default globals so that later we can remove any that
-    // were created by the dweet
-    var browserGlobals = {};
-    Object.keys(window).forEach(key => {
-      browserGlobals[key] = true;
-    });
 
     var c = document.querySelector("#c");
         
@@ -290,9 +292,7 @@
     function reset(){
       Object.keys(window).forEach(key => {
         if (!browserGlobals[key]) {
-          if (window.debug) {
-            console.log("Removing new global: " + key);
-          }
+          console.log("Removing new global: " + key);
           delete window[key];
         }
       });
@@ -416,7 +416,11 @@
         }
       }
     }
-    
-    </script>
+
+    // Remember any new globals added by this script too
+    Object.keys(window).forEach(key => {
+      browserGlobals[key] = true;
+    });
+  </script>
 
 </body>

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -415,6 +415,7 @@
 
     // Remember the default globals so that later we can remove any that
     // were created by the dweet
+    browserGlobals = {};
     Object.keys(window).forEach(key => {
       browserGlobals[key] = true;
     });

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -29,7 +29,7 @@
       var username;
       var minGIFWidth = 640;
 
-      var browserGlobals = {};
+      var browserGlobals = null;
 
       function receiveMessage(event){
         var origin = event.origin || event.originalEvent.origin;
@@ -181,13 +181,6 @@
     <script src="{% static "libs/loopbuster.js" %}"></script>
     <script src="{% static "libs/loopstopper.js" %}"></script>
     {% endcompress %}
-    <script>
-      // Remember the default globals so that later we can remove any that
-      // were created by the dweet
-      Object.keys(window).forEach(key => {
-        browserGlobals[key] = true;
-      });
-    </script>
   </head>
 <body>
   <canvas id=c></canvas>
@@ -290,12 +283,15 @@
     }
 
     function reset(){
-      Object.keys(window).forEach(key => {
-        if (!browserGlobals[key]) {
-          console.log("Removing new global: " + key);
-          delete window[key];
-        }
-      });
+      if (browserGlobals) {
+        Object.keys(window).forEach(key => {
+          if (!browserGlobals[key]) {
+            console.log("Removing new global: " + key);
+            delete window[key];
+          }
+        });
+      }
+
       c = document.querySelector("#c");
       c.width = 1920;
       c.height = 1080;
@@ -417,7 +413,8 @@
       }
     }
 
-    // Remember any new globals added by this script too
+    // Remember the default globals so that later we can remove any that
+    // were created by the dweet
     Object.keys(window).forEach(key => {
       browserGlobals[key] = true;
     });


### PR DESCRIPTION
The problem was that sometimes Firefox would call `postMessage()` after the first `<script>` had loaded, but _before_ the second `<script>` had loaded.

If this happened, then `reset()` would break because `browserGlobals` had not yet been built.

This fix starts `browserGlobals` off as null, and only starts using it for cleanup once it has been built (which is now the last thing done when the page loads).

I also re-enabled `browserGlobals` logging in case there are any more problems in future. We can turn it off in a couple of months, if everything is working fine.

Tested:
- Dweets play in Firefox and Chrome
- New Dweet works in Firefox and Chrome

Not tested:
- Scrolling to second page of dweets. (My dev machine only had 5 dweets in the DB right now!)

Note: The first commit was more thorough, but probably overkill for editing. Let's KISS for now, with the second commit.