### PR TITLE
Increase loopbuster timeout to 4 seconds (from half a second)

### DIFF
--- a/dwitter/static/libs/loopstopper.js
+++ b/dwitter/static/libs/loopstopper.js
@@ -2,7 +2,7 @@ window.stopper = {
 
   loops: [],
   loopTimers: [],
-  TIME_OUT_LENGTH: 500,
+  TIME_OUT_LENGTH: 4000,
   states: Object.freeze({ 
     UNMONITORED: 0,
     MONITORED: 1,


### PR DESCRIPTION
This should enable users on slow machines/devices to view some of the heavier dweets.

At the same time, it will not leave their device completely unresponsive. After 4 seconds, the dweet gets killed.

I was tempted to go to 8 seconds, but managed to restrain myself. I guess very few dweets need more than 4 seconds.

Having any limit at all is great for users.