### PR TITLE
Improved green theme + other minor theme patches

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -1,737 +1,776 @@
 * {
-  border:0px;
-  margin:0px;
-  padding:0px;
+    border: 0px;
+    margin: 0px;
+    padding: 0px;
 }
 
 .clear-fix:after {
-  content: "";
-  display: table;
-  clear: both;
+    content: "";
+    display: table;
+    clear: both;
 }
 
 .avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 18px;
-  background: #ccc no-repeat center;
-  background-size: cover;
-  overflow: hidden;
-  display: inline-block;
-  vertical-align: middle;
-  box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+    width: 36px;
+    height: 36px;
+    border-radius: 18px;
+    background: #ccc no-repeat center;
+    background-size: cover;
+    overflow: hidden;
+    display: inline-block;
+    vertical-align: middle;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
 }
 
-textarea{
-  border:1px solid;
-  padding:3px;
+textarea {
+    border: 1px solid;
+    padding: 3px;
 }
 
-input[type=text], input[type=email] {
-  border:1px solid;
-  padding:3px;
-  border-radius: 2px;
-  font-family: 'Roboto', sans-serif;
-}
-input[type=submit], input[type=button] {
-  padding: 5px;
-  border: 1px solid black;
-  background: white;
-  border-radius:3px;
-  display:inline-block;
-  font-family: 'Roboto', sans-serif;
+input[type="text"],
+input[type="email"] {
+    border: 1px solid;
+    padding: 3px;
+    border-radius: 2px;
+    font-family: "Roboto", sans-serif;
 }
 
-input[type=submit].dweet-button {
-  float: right;
+input[type="submit"],
+input[type="button"] {
+    padding: 5px;
+    border: 1px solid black;
+    background: white;
+    border-radius: 3px;
+    display: inline-block;
+    font-family: "Roboto", sans-serif;
 }
 
-input[type=submit].remix-button {
-  float: right;
-  clear: both;
-  margin-top: 5px;
+input[type="submit"].dweet-button {
+    float: right;
 }
 
-input[type=submit].delete-button {
-  color: red;
-  background: transparent;
-  border: 0;
-  outline: 0;
-  font-size: 16px;
-  font-family: 'Roboto', sans-serif;
+input[type="submit"].remix-button {
+    float: right;
+    clear: both;
+    margin-top: 5px;
+}
+
+input[type="submit"].delete-button {
+    color: red;
+    background: transparent;
+    border: 0;
+    outline: 0;
+    font-size: 16px;
+    font-family: "Roboto", sans-serif;
 }
 
 .error-display {
-  color: red;
-  font-size: small;
-  font-family: 'Roboto', sans-serif;
+    color: red;
+    font-size: small;
+    font-family: "Roboto", sans-serif;
 }
 
 a {
-  color: #666;
-  text-decoration: none;
-}
-a:hover {
-  text-decoration: underline;
-}
-p a, .comment-message a {
-  color: #4599ca;
-  text-decoration: none;
+    color: #666;
+    text-decoration: none;
 }
 
-.button{
-  padding: 5px;
-  border: 1px solid black;
-  background: white;
-  border-radius:3px;
-  margin-top: 2px;
-  text-decoration:none;
-  display:inline-block;
+a:hover {
+    text-decoration: underline;
+}
+
+p a,
+.comment-message a {
+    color: #4599ca;
+    text-decoration: none;
+}
+
+.button {
+    padding: 5px;
+    border: 1px solid black;
+    background: white;
+    border-radius: 3px;
+    margin-top: 2px;
+    text-decoration: none;
+    display: inline-block;
 }
 
 a.button,
 a.button:hover,
 a.button:active,
 a.button:visited {
-  color:inherit;
+    color: inherit;
 }
 
-
-body{
-  background:#f5f5f5;
-  font-family: 'Roboto', sans-serif;
-  font-size: 16px;
-  line-height: 1.58;
-  letter-spacing: -0.003;
+body {
+    background: #f5f5f5;
+    font-family: "Roboto", sans-serif;
+    font-size: 16px;
+    line-height: 1.58;
+    letter-spacing: -0.003;
 }
-body.embed{
-  background:#ffffff;
+
+body.embed {
+    background: #ffffff;
 }
 
 code {
-  font-family: Pragmata, Menlo, 'DejaVu LGC Sans Mono', 'DejaVu Sans Mono', Consolas, 'Everson Mono', 'Lucida Console', 'Andale Mono', 'Nimbus Mono L', 'Liberation Mono', FreeMono, 'Osaka Monospaced', Courier, 'New Courier', monospace;
-  white-space: pre-line;
+    font-family: Pragmata, Menlo, "DejaVu LGC Sans Mono", "DejaVu Sans Mono",
+        Consolas, "Everson Mono", "Lucida Console", "Andale Mono",
+        "Nimbus Mono L", "Liberation Mono", FreeMono, "Osaka Monospaced",
+        Courier, "New Courier", monospace;
+    white-space: pre-line;
 }
 
 ul.messages {
-  text-align: center;
-  margin: 4;
-  padding: 0.5em;
-  list-style: none;
-}
-ul.messages li{
-  background: #DEF0D8;
-  margin: 4 auto;
-  max-width: 585;
-  border:1px solid #ddd;
+    text-align: center;
+    margin: 4;
+    padding: 0.5em;
+    list-style: none;
 }
 
-ul.messages li.warning{
-  background: #ffcece;
+ul.messages li {
+    background: #def0d8;
+    margin: 4 auto;
+    max-width: 585;
+    border: 1px solid #ddd;
 }
 
-ul.messages li.success{
-  background: #DEF0D8;
+ul.messages li.warning {
+    background: #ffcece;
+}
+
+ul.messages li.success {
+    background: #def0d8;
 }
 
 #content {
-  padding: 50px 0 1em;
-  margin: 0 auto;
+    padding: 50px 0 1em;
+    margin: 0 auto;
 }
 
 .content-div {
-  max-width: 600px;
-  margin: 15px auto;
-  padding: 15px;
-  background:white;
-  word-wrap: break-word;
-  border:1px solid #ddd;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
-  overflow: hidden;
+    max-width: 600px;
+    margin: 15px auto;
+    padding: 15px;
+    background: white;
+    word-wrap: break-word;
+    border: 1px solid #ddd;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    overflow: hidden;
 }
 
 .content-div input {
-  border:1px solid #ddd;
+    border: 1px solid #ddd;
 }
+
 .dweet .code {
-  white-space: pre;
-  word-wrap: break;
+    white-space: pre;
+    word-wrap: break;
 }
 
 .dweet-feed {
-  max-width: 600px;
-  margin: 0 auto;
-  padding: 0 15px;
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 0 15px;
 }
 
-.dweet, .card, .loading, .end-of-feed {
-  margin-top: 15px;
-  padding: 15px;
-  background:white;
-  word-wrap: break-word;
-  border:1px solid #ddd;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+.dweet,
+.card,
+.loading,
+.end-of-feed {
+    margin-top: 15px;
+    padding: 15px;
+    background: white;
+    word-wrap: break-word;
+    border: 1px solid #ddd;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
-.loading, .end-of-feed {
-  text-align: center;
+.loading,
+.end-of-feed {
+    text-align: center;
 }
 
-.comment-section{
-  background: #fbfbfb;
-  padding: 20px;
-  border-left: 1px solid #ddd;
-  border-right: 1px solid #ddd;
-  box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+.comment-section {
+    background: #fbfbfb;
+    padding: 20px;
+    border-left: 1px solid #ddd;
+    border-right: 1px solid #ddd;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
-.comments,.sticky-comments {
-  list-style-type: none;
-  padding: none;
+.comments,
+.sticky-comments {
+    list-style-type: none;
+    padding: none;
 }
 
-.comment.sticky-comment{
-  font-weight:bold;
+.comment.sticky-comment {
+    font-weight: bold;
 }
 
-.comment-name{
-  font-weight:bold;
+.comment-name {
+    font-weight: bold;
 }
 
 .comment-message {
-  overflow-wrap: break-word;
-  word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 }
 
 .comment-message code {
-  font-size: 13px;
-  line-height: 25.28px;
-  padding: .25em;
-  background: hsl(0, 0%, 92.5%);
-  color: hsl(250, 55%, 60%);
+    font-size: 13px;
+    line-height: 25.28px;
+    padding: 0.25em;
+    background: hsl(0, 0%, 92.5%);
+    color: hsl(250, 55%, 60%);
 }
 
 .new-comment {
-  margin-top: 10px;
-  display: flex;
-  display: -webkit-flex;
+    margin-top: 10px;
+    display: flex;
+    display: -webkit-flex;
 }
 
-.comment-input{
-  flex: 1;
-  text-align:left;
-  width:80%;
+.comment-input {
+    flex: 1;
+    text-align: left;
+    width: 80%;
 }
 
 input.comment-submit {
-  padding: 3px;
-  margin: 0;
-  margin-left: 5px;
-  color: currentcolor;
-  cursor: pointer;
+    padding: 3px;
+    margin: 0;
+    margin-left: 5px;
+    color: currentcolor;
+    cursor: pointer;
 }
+
 input.comment-submit:active {
-  transform: translateY(1px);
+    transform: translateY(1px);
 }
 
 .submit-box {
-  background:white;
-  border:1px solid #ddd;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
-  padding: 15px;
-  display: none;
+    background: white;
+    border: 1px solid #ddd;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    padding: 15px;
+    display: none;
 }
 
 .dweet-create-form-title {
-  background: #4599ca;
-  color: white;
-  font-size: 1.1em;
-  cursor: pointer;
-  font-weight: bold;
-  text-align: center;
-  padding: 10px;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 5px;
-  height: 20px;
-  line-height: 20px;
-  float: right;
+    background: #4599ca;
+    color: white;
+    font-size: 1.1em;
+    cursor: pointer;
+    font-weight: bold;
+    text-align: center;
+    padding: 10px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 5px;
+    height: 20px;
+    line-height: 20px;
+    float: right;
 }
 
 .dweet-create-form-title:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 .dweet-create-form-title .add-icon {
-  background: white;
-  color: #4599ca;
-  border-radius: 50%;
-  width: 20px;
-  height: 20px;
-  display: inline-block;
-  margin-right: 10px;
+    background: white;
+    color: #4599ca;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    display: inline-block;
+    margin-right: 10px;
 }
 
-.author-remix-wrapper{
-  padding: 10px 0;
-  display: inline-block;
-  width: 100%;
+.author-remix-wrapper {
+    padding: 10px 0;
+    display: inline-block;
+    width: 100%;
 }
 
 .dweet-author {
-  font-weight: bold;
-  float:left;
-  font-size:large;
-  display:block;
+    font-weight: bold;
+    float: left;
+    font-size: large;
+    display: block;
 }
 
 .remix-info {
-  font-weight: bold;
-  float:right;
+    font-weight: bold;
+    float: right;
 }
 
 .faded {
-  opacity: 0.5;
+    opacity: 0.5;
 }
 
 .function-wrap {
-  color:gray;
-  font-size:small;
-  float: left;
+    color: gray;
+    font-size: small;
+    float: left;
 }
 
-.code-input{
-  text-align:left;
-  resize:none;
-  width:100%;
-  font-family: Pragmata, Menlo, 'DejaVu LGC Sans Mono', 'DejaVu Sans Mono', Consolas, 'Everson Mono', 'Lucida Console', 'Andale Mono', 'Nimbus Mono L', 'Liberation Mono', FreeMono, 'Osaka Monospaced', Courier, 'New Courier', monospace;
-  white-space: pre-line;
-  word-break: break-all;
-  max-height:20em;
+.code-input {
+    text-align: left;
+    resize: none;
+    width: 100%;
+    font-family: Pragmata, Menlo, "DejaVu LGC Sans Mono", "DejaVu Sans Mono",
+        Consolas, "Everson Mono", "Lucida Console", "Andale Mono",
+        "Nimbus Mono L", "Liberation Mono", FreeMono, "Osaka Monospaced",
+        Courier, "New Courier", monospace;
+    white-space: pre-line;
+    word-break: break-all;
+    max-height: 20em;
 }
 
 .canvas-iframe-container-wrapper {
-  width: 100%;
-  /*padding: 0 0 56.25% 0; /* 16:9 */
-  padding: 0 0 56.25% 0; /* 16:9 */
-  position: relative;
+    width: 100%;
+    /*padding: 0 0 56.25% 0; /* 16:9 */
+    padding: 0 0 56.25% 0;
+    /* 16:9 */
+    position: relative;
 }
 
 .canvas-iframe-container {
-  position: absolute;
-  width:100%;
-  top: 0; bottom: 0; left: 0; right: 0;
-  overflow: hidden;
+    position: absolute;
+    width: 100%;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    overflow: hidden;
 }
+
 iframe {
-  width:100%;
-  height:100%;
+    width: 100%;
+    height: 100%;
 }
 
 .head-menu {
-  position: fixed;
-  z-index: 100;
-  width:100%;
-  background:white;
-  text-align:left;
-  border-bottom:1px solid #ddd;
-  box-shadow:0px 0px 2px rgba(0,0,0,0.051);
-  padding: 5px 0;
-  line-height: 40px;
+    position: fixed;
+    z-index: 100;
+    width: 100%;
+    background: white;
+    text-align: left;
+    border-bottom: 1px solid #ddd;
+    box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.051);
+    padding: 5px 0;
+    line-height: 40px;
 }
 
 .head-menu-inner {
-  position: relative;
-  max-width: 960px;
-  margin: 0 auto;
-  padding-left: 1em;
+    position: relative;
+    max-width: 960px;
+    margin: 0 auto;
+    padding-left: 1em;
 }
 
 /* Enable hide/show styles for the header when scrolling, but only at low res. */
+
 /* A dweet canvas never grows taller than 320px, so after 420px both canvas and bloated header can fit on screen. */
+
 /* But if we want to accomodate the entire dweet box that's 572px max box height + 56px for small header - margins = 620px */
+
 @media (max-height: 620px) {
-  .head-menu {
-    transform: translateY(0);
-    transition: transform 0.3s ease-out;
-  }
-  .head-menu.hidden {
-    transform: translateY(-150px);
-    transition: transform 0.3s ease-out;
-  }
+    .head-menu {
+        transform: translateY(0);
+        transition: transform 0.3s ease-out;
+    }
+    .head-menu.hidden {
+        transform: translateY(-150px);
+        transition: transform 0.3s ease-out;
+    }
 }
 
 .next-page {
-  display:none;
+    display: none;
 }
+
 .head-account-info {
-  margin: 0 1em;
-  float: right;
-  text-align: right;
+    margin: 0 1em;
+    float: right;
+    text-align: right;
 }
 
 .head-account-info .avatar {
-  margin-left: 6px;
+    margin-left: 6px;
 }
 
 .head-account-info .name {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  display: inline-block;
-  vertical-align: middle;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: inline-block;
+    vertical-align: middle;
 }
 
 @media (max-width: 768px) {
-  .head-account-info {
-    width: 36px;
-  }
-  .head-account-info .avatar {
-    margin: 0;
-  }
-  .head-account-info .name {
-    display: none;
-  }
+    .head-account-info {
+        width: 36px;
+    }
+    .head-account-info .avatar {
+        margin: 0;
+    }
+    .head-account-info .name {
+        display: none;
+    }
 }
 
 @media (max-width: 660px) {
-  #content {
-    padding-top: 90px;
-  }
+    #content {
+        padding-top: 90px;
+    }
 }
 
 @media (max-width: 350px) {
-  .dweet-create-form-title-label span {
-    display: none;
-  }
+    .dweet-create-form-title-label span {
+        display: none;
+    }
 }
 
 .head-account-info .collapsible {
-  position: absolute;
-  border: 1px solid #ddd;
-  right: 1rem;
-  z-index: 10;
-  transition: opacity .1s ease-in-out, margin .1s step-end;
-  opacity: 0;
-  height: 0;
-  margin-top: -9999px;
-  font-size: 0.8em;
+    position: absolute;
+    border: 1px solid #ddd;
+    right: 1rem;
+    z-index: 10;
+    transition: opacity 0.1s ease-in-out, margin 0.1s step-end;
+    opacity: 0;
+    height: 0;
+    margin-top: -9999px;
+    font-size: 0.8em;
 }
 
 .head-account-info.is-logged-in:hover {
-  background: #ddd;
+    background: #ddd;
 }
 
 .head-account-info.is-logged-in:hover .collapsible {
-  display: block;
-  opacity: 1;
-  margin-top: 0;
-  transition: opacity .1s ease-in-out, margin .1s step-start;
+    display: block;
+    opacity: 1;
+    margin-top: 0;
+    transition: opacity 0.1s ease-in-out, margin 0.1s step-start;
 }
 
 .head-account-info .collapsible li {
-  list-style-type: none;
-  background: white;
-  border-bottom: 1px solid #ddd;
-  width: 150px;
-  padding: 14px;
-  line-height: normal;
+    list-style-type: none;
+    background: white;
+    border-bottom: 1px solid #ddd;
+    width: 150px;
+    padding: 14px;
+    line-height: normal;
 }
 
 .header-center-div {
-  margin:auto;
-  width:30%;
-  padding:1px;
-  text-align:center;
+    margin: auto;
+    width: 30%;
+    padding: 1px;
+    text-align: center;
 }
 
 .header-title {
-  margin-right: 1em;
-  display: inline-block;
+    margin-right: 1em;
+    display: inline-block;
 }
 
 .footer {
-  background:white;
-  text-align:center;
+    background: white;
+    text-align: center;
 }
 
 form.like {
-  display: inline-block;
-  vertical-align: middle;
+    display: inline-block;
+    vertical-align: middle;
 }
 
 .record-button {
-  outline: none;
-  width: 11em;
-  text-align: right;
-  background: transparent;
+    outline: none;
+    width: 11em;
+    text-align: right;
+    background: transparent;
 }
 
 .record-text {
-  color: #666;
-  font-family: 'Roboto', sans-serif;
-  font-size: 1rem;
+    color: #666;
+    font-family: "Roboto", sans-serif;
+    font-size: 1rem;
 }
 
 .like-button {
-  background: #eee;
-  border-radius: 4px;
-  border: 1px solid #ddd;
-  padding: 3px 6px 3px 3px;
-  font-size: 1rem;
-  font-weight: bold;
-  overflow: hidden;
-  cursor: pointer;
-  display: inline-block;
+    background: #eee;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    padding: 3px 6px 3px 3px;
+    font-size: 1rem;
+    font-weight: bold;
+    overflow: hidden;
+    cursor: pointer;
+    display: inline-block;
 }
 
 .like-button.liked {
-  background: linear-gradient(to top, #2ab6e1, #4599ca);
+    background: linear-gradient(to top, #2ab6e1, #4599ca);
 }
 
-.like-button.liked .like-text{
-  color: white;
-  text-shadow: 0 -1px rgba(106, 130, 135, 0.5);
+.like-button.liked .like-text {
+    color: white;
+    text-shadow: 0 -1px rgba(106, 130, 135, 0.5);
 }
 
 .record-button .record-icon {
-  width: 0;
-  height: 1em;
-  display: inline-block;
-  vertical-align: bottom;
-  margin-bottom: 2px;
-  border-radius: 50%;
-  background-color: red;
-  transition-duration: 0.3s;
+    width: 0;
+    height: 1em;
+    display: inline-block;
+    vertical-align: bottom;
+    margin-bottom: 2px;
+    border-radius: 50%;
+    background-color: red;
+    transition-duration: 0.3s;
 }
 
 .record-button.recording .record-icon {
-  width: 1em;
+    width: 1em;
 }
 
 .record-button.processing .record-icon {
-  width: 1em;
-  background: rgba(0, 0, 0, 0);
-  border-radius: 50%;
-  border: 3px solid rgba(0, 0, 0, 0);
-  border-top: 3px solid red;
-  animation: load 1s linear infinite;
+    width: 1em;
+    background: rgba(0, 0, 0, 0);
+    border-radius: 50%;
+    border: 3px solid rgba(0, 0, 0, 0);
+    border-top: 3px solid red;
+    animation: load 1s linear infinite;
 }
 
 @keyframes load {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
 }
 
 .like-button.liked:hover {
-  background: linear-gradient(to top, #e1362a, #ca3945);
+    background: linear-gradient(to top, #e1362a, #ca3945);
 }
 
 .like-button:hover {
-  text-decoration: none;
-  background: #ddd;
-  border-color: #ccc;
+    text-decoration: none;
+    background: #ddd;
+    border-color: #ccc;
 }
 
 .score-text {
-  font-weight: normal;
-  background: white;
-  padding: 3px;
-  margin-left: -3px;
-  border-right: 1px solid #ddd;
+    font-weight: normal;
+    background: white;
+    padding: 3px;
+    margin-left: -3px;
+    border-right: 1px solid #ddd;
 }
 
 .character-count {
-  display: inline-block;
-  vertical-align: middle;
+    display: inline-block;
+    vertical-align: middle;
 }
 
 .character-count.too-long {
-  color: red;
+    color: red;
 }
 
-
 .dweet-changed {
-  display: none;
-  text-align: right;
-  color: white;
+    display: none;
+    text-align: right;
+    color: white;
 }
 
 .dweet-changed > p {
-  text-align: left;
+    text-align: left;
 }
 
-.show-stats, .hide-stats {
-  display: none;
+.show-stats,
+.hide-stats {
+    display: none;
 }
 
 .hide-stats.visible {
-  display: initial;
+    display: initial;
 }
 
 .dweet-option {
-  flex-grow: 0;
-  padding:5px;
+    flex-grow: 0;
+    padding: 5px;
 }
 
 .popover {
-  display: none;
-  position: absolute;
-  top: 2em;
-  background: white;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-  padding: 1em;
-  z-index: 100;
+    display: none;
+    position: absolute;
+    top: 2em;
+    background: white;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    padding: 1em;
+    z-index: 100;
 }
 
 .popover ul {
-  list-style-type: none;
+    list-style-type: none;
 }
 
 .share-container li {
-  text-align: right;
+    text-align: right;
 }
 
 .share-container input {
-  /* Wide enough so that a five digit dweet ID displays fully, with a small gap left over */
-  width: 15.5em;
+    /* Wide enough so that a five digit dweet ID displays fully, with a small gap left over */
+    width: 15.5em;
 }
 
 .remixes-container li {
-  padding: 5px 0;
+    padding: 5px 0;
 }
 
-.dweet-timestamp{
-  float: right;
-  display: inline-block;
-  vertical-align: middle;
-  color:gray;
-  font-size:small;
-  font-family: Pragmata, Menlo, 'DejaVu LGC Sans Mono', 'DejaVu Sans Mono', Consolas, 'Everson Mono', 'Lucida Console', 'Andale Mono', 'Nimbus Mono L', 'Liberation Mono', FreeMono, 'Osaka Monospaced', Courier, 'New Courier', monospace;
+.dweet-timestamp {
+    float: right;
+    display: inline-block;
+    vertical-align: middle;
+    color: gray;
+    font-size: small;
+    font-family: Pragmata, Menlo, "DejaVu LGC Sans Mono", "DejaVu Sans Mono",
+        Consolas, "Everson Mono", "Lucida Console", "Andale Mono",
+        "Nimbus Mono L", "Liberation Mono", FreeMono, "Osaka Monospaced",
+        Courier, "New Courier", monospace;
 }
 
 .dweet-actions {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  margin-top:10px;
-  margin-bottom:20px;
-  position: relative;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    margin-top: 10px;
+    margin-bottom: 20px;
+    position: relative;
 }
 
 .dweet-actions > form.like {
-  flex-grow: 1;
-  margin: auto 0;
+    flex-grow: 1;
+    margin: auto 0;
 }
 
 .top-sort-list {
-  list-style-type:none;
-  padding:0;
-  display: inline-block;
+    list-style-type: none;
+    padding: 0;
+    display: inline-block;
 }
+
 .top-sort-list li {
-  display: inline-block;
-  padding-right: 15px;
+    display: inline-block;
+    padding-right: 15px;
 }
+
 .top-sort-list a {
-  text-decoration:none;
-  color:#333;
+    text-decoration: none;
+    color: #333;
 }
+
 .top-sort-list a:hover {
-  text-decoration:underline;
+    text-decoration: underline;
 }
 
 body.new .top-sort-list a.new {
-  font-weight: bold;
+    font-weight: bold;
 }
+
 body.top .top-sort-list a.top {
-  font-weight: bold;
+    font-weight: bold;
 }
+
 body.hot .top-sort-list a.hot {
-  font-weight: bold;
+    font-weight: bold;
 }
+
 body.random .top-sort-list a.random {
-  font-weight: bold;
+    font-weight: bold;
 }
+
 body.awesome .top-sort-list a.awesome {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 #submit-preview {
 }
 
-.submit-help{
-  font-size: 0.8em;
+.submit-help {
+    font-size: 0.8em;
 }
 
 .delete {
-  color: #b22;
+    color: #b22;
 }
 
 .settings-form {
-  text-align: center;
+    text-align: center;
 }
 
 .settings-form label {
-  width: 100px;
-  display: inline-block;
-  font-size: 14px;
-  text-align: right;
+    width: 100px;
+    display: inline-block;
+    font-size: 14px;
+    text-align: right;
 }
 
 .settings-form input {
-  margin-top: 6px;
-  text-align: left;
+    margin-top: 6px;
+    text-align: left;
 }
 
-.settings-form input[type=submit] {
-  float: right;
+.settings-form input[type="submit"] {
+    float: right;
 }
 
 .center-settings {
-  max-width: 400px;
-  margin: 0 auto;
-  text-align: center;
+    max-width: 400px;
+    margin: 0 auto;
+    text-align: center;
 }
 
 .center-settings p {
-  margin: 15px;
+    margin: 15px;
 }
 
 .avatar-large {
-  width: 150px;
-  height: 150px;
-  border-radius: 75px;
+    width: 150px;
+    height: 150px;
+    border-radius: 75px;
 }
 
 .dark-section {
-  margin: 10px -15px -15px;
-  background: #222;
-  padding: 15px;
-  overflow: hidden;
+    margin: 10px -15px -15px;
+    background: #222;
+    padding: 15px;
+    overflow: hidden;
 }
 
 .dark-section .dweet-code textarea {
-  background: transparent;
-  border: 0;
-  color: white;
-  outline: 0;
-  font-size: small;
-  padding: 0;
-  padding-left: 1em;
+    background: transparent;
+    border: 0;
+    color: white;
+    outline: 0;
+    font-size: small;
+    padding: 0;
+    padding-left: 1em;
 }
 
-.dark-section .dweet-code textarea:focus {
-  outline: 0;
+.dark-section .dweet-code textarea:focus {
+    outline: 0;
 }
 
 .dweet-delete-form {
-  display: inline-block;
-  vertical-align: middle;
-  padding: 3px;
+    display: inline-block;
+    vertical-align: middle;
+    padding: 3px;
 }
 
 form.accounts {
@@ -754,9 +793,9 @@ form.accounts label {
     font-size: 14px;
 }
 
-form.accounts input[type=text],
-form.accounts input[type=email],
-form.accounts input[type=password] {
+form.accounts input[type="text"],
+form.accounts input[type="email"],
+form.accounts input[type="password"] {
     margin-bottom: 15px;
     font-size: 16px;
     width: 100%;
@@ -767,7 +806,7 @@ form.accounts input[type=password] {
     border-bottom: 1px solid #aaa;
 }
 
-form.accounts input[type=submit] {
+form.accounts input[type="submit"] {
     float: right;
     text-transform: uppercase;
     color: #666;

--- a/dwitter/static/theme_dark.css
+++ b/dwitter/static/theme_dark.css
@@ -1,131 +1,141 @@
 textarea {
-  border: none;
+    border: none;
 }
 
-ul.messages li{
-  border:1px solid black;
+ul.messages li {
+    border: 1px solid black;
 }
 
 .content-div {
-  background:#4b4b4b;
-  color: white;
-  border:1px solid black;
+    background: #4b4b4b;
+    color: white;
+    border: 1px solid black;
 }
 
 .content-div input {
-  border:1px solid black;
+    border: 1px solid black;
 }
-.dweet, .card, .loading, .end-of-feed {
-  border:1px solid black;
+
+.dweet,
+.card,
+.loading,
+.end-of-feed {
+    border: 1px solid black;
+    background: #4b4b4b;
 }
 
 .submit-box {
-  border:1px solid black;
+    border: 1px solid black;
+    background: #4b4b4b;
+    color: white;
 }
 
 .dweet-create-form-title {
-  background: #ffa500;
+    background: #ffa500;
 }
 
 .dweet-create-form-title:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 .dweet-create-form-title .add-icon {
-  color: rgba(215, 125, 0, 1);
+    color: rgba(215, 125, 0, 1);
 }
 
 .head-menu {
-  background-color: #4b4b4b;
-  border-bottom:1px solid black;
+    background-color: #4b4b4b;
+    border-bottom: 1px solid black;
 }
 
 .head-account-info .collapsible {
-  border: 1px solid black !important;
+    border: 1px solid black !important;
 }
 
 .head-account-info.is-logged-in:hover {
-  background: #666;
+    background: #666;
 }
 
 .head-account-info .collapsible li {
-  border-bottom: none;
-  color: #666;
+    border-bottom: none;
+    color: #666;
 }
 
 .header-title {
-  color: white;
+    color: white;
 }
 
 .like-button {
-  border: 1px solid black;
+    border: 1px solid black;
 }
 
 .dark-section .dweet-code textarea {
-  border: none;
+    border: none;
 }
 
 .dark-section .dweet-code textarea:focus {
-  border: none;
+    border: none;
 }
 
 /* Dark-theme-specific properties */
 
 .head-menu a {
-  color: white;
+    color: white;
 }
 
-.body{
-  background: #383838;
+.body {
+    background: #383838;
 }
 
-.header-title a{
-  color: white;
+.header-title a {
+    color: white;
 }
 
-.head-account-info .name{
-  color: white;
+.head-account-info .name {
+    color: white;
 }
 
-body{
-  background: #383838;
+body {
+    background: #383838;
 }
 
-
-.head-account-info.is-logged-in .collapsible li{
-  background: #666;
+.head-account-info.is-logged-in .collapsible li {
+    background: #666;
 }
 
-#settings-list{
-  border:1px solid black;
-  border-top: none;
+#settings-list {
+    border: 1px solid black;
+    border-top: none;
 }
 
-.card{
- background: #4b4b4b;
- color:white;
+.card {
+    background: #4b4b4b;
+    color: white;
 }
 
-.comment-section{
-  background: #4b4b4b;
-  color: white;
-  border: 1px solid black;
+.comment-section {
+    background: #4b4b4b;
+    color: white;
+    border: 1px solid black;
 }
 
-.comment-name{
-  color: #ffa500;
+.comment-name {
+    color: #ffa500;
 }
 
 input.comment-submit {
-  color: black;
+    color: black;
 }
 
-.end-of-feed{
-  background: #4b4b4b !important;
-  color: white;
+.end-of-feed {
+    background: #4b4b4b !important;
+    color: white;
 }
 
 .comment-message code {
-  background: #404040;
-  color: hsl(250, 55%, 65%);
+    background: #404040;
+    color: hsl(250, 55%, 65%);
+}
+
+a {
+    color: white;
 }

--- a/dwitter/static/theme_dark.css
+++ b/dwitter/static/theme_dark.css
@@ -83,7 +83,7 @@ ul.messages li {
 }
 
 .body {
-    background: #383838;
+    background: black;
 }
 
 .header-title a {

--- a/dwitter/static/theme_green.css
+++ b/dwitter/static/theme_green.css
@@ -1,0 +1,229 @@
+body {
+    /* For any unstyled text.  Currently this applies to the "remix of ..." text. */
+    color: darkgray !important;
+    background-color: slateblue;
+}
+
+:focus {
+    outline-color: lime;
+}
+
+textarea {
+    border: none;
+}
+
+ul.messages li.success {
+    background: #001b00;
+    color: lime;
+}
+
+ul.messages li {
+    border-color: black;
+}
+
+.dweet {
+    background: #001b00;
+}
+
+.content-div {
+    background: #001b00;
+    color: lime;
+    border: 1px solid black;
+}
+
+.content-div input {
+    border: 1px solid black;
+}
+
+.dweet,
+.card,
+.loading,
+.end-of-feed {
+    border: 1px solid black;
+}
+
+.submit-box {
+    border: 1px solid black;
+}
+
+.dweet-create-form-title {
+    background: #003402;
+    color: lime;
+}
+
+.dweet-create-form-title:hover {
+    text-decoration: underline;
+}
+
+.dweet-create-form-title .add-icon {
+    background: lime;
+    color: #003402;
+}
+
+.head-menu {
+    background: #001000;
+    border-bottom: 1px solid #111;
+}
+
+.head-account-info .collapsible {
+    border: 1px solid black !important;
+}
+
+.head-account-info.is-logged-in:hover {
+    background: #141d14;
+}
+
+.head-account-info .collapsible li {
+    border-bottom: none;
+    color: #ff0606;
+}
+
+.header-title {
+    color: #00ff24;
+}
+
+.score-text {
+    background: black;
+    border: none;
+}
+
+.dark-section .dweet-code textarea {
+    border: none;
+    color: lime;
+}
+
+.dark-section .dweet-code textarea:focus {
+    border: none;
+}
+
+.head-menu a {
+    color: #17ff00;
+}
+
+.head-menu {
+    background: #001000;
+}
+
+.header-title a {
+    color: lime;
+}
+
+.head-account-info .name {
+    color: lime;
+    font-size: large;
+}
+
+body {
+    background: #383838;
+}
+
+.head-account-info.is-logged-in .collapsible li {
+    background: #042b00;
+}
+
+#settings-list {
+    border: 1px solid black;
+    border-top: none;
+}
+
+.card {
+    background: #001b00;
+    color: lime;
+}
+
+textarea#editor.code-input {
+    color: #6aff31;
+}
+
+.comment-section {
+    background: #001b00;
+    color: #00ff53;
+    border: 1px solid black;
+}
+
+.comment-name {
+    color: #3bff00;
+}
+
+input,
+input[type="text"].new-dweet-comment-input {
+    border: 1px solid #3bff00;
+    background: #020e00;
+    color: #3bff00;
+}
+
+/* We have to get more specific for the like button, to override the default selector */
+
+button,
+input[type="button"],
+input[type="submit"],
+.like-button {
+    border-color: #38ff00;
+    background-color: #003100;
+    /* background: #0a2b00; */
+    color: #38ff00 !important;
+}
+
+button:hover,
+input[type="button"]:hover,
+input[type="submit"]:hover,
+.like-button:hover {
+    border-color: #38ff00;
+    background-color: #006200;
+}
+
+a,
+.record-text {
+    color: lime;
+}
+
+div.dark-section {
+    /* background: #002500ab */
+    background: #0006;
+}
+
+.end-of-feed {
+    background: #001b00;
+    color: lime;
+}
+
+.comment-message code {
+    background: #4040406e;
+    color: hsl(117, 100%, 50%);
+}
+
+.dweet-button {
+    color: #043c00;
+    background: #74ce54;
+}
+
+.function-wrap {
+    color: #005000;
+}
+
+.submit-help {
+    color: lime;
+}
+
+.liked {
+    color: red;
+}
+
+.like-button.liked {
+    border-color: #3bff00;
+    background: #3bff00;
+}
+
+.like-button.liked .like-text {
+    color: #000;
+}
+
+.like-button.liked:hover {
+    border-color: #38ff00;
+    background-color: #1a8000;
+}
+
+.record-text:hover,
+input.delete-button:hover {
+    text-decoration: underline;
+}

--- a/dwitter/static/theme_green.css
+++ b/dwitter/static/theme_green.css
@@ -1,7 +1,7 @@
 body {
     /* For any unstyled text.  Currently this applies to the "remix of ..." text. */
-    color: darkgray !important;
-    background-color: slateblue;
+    color: lime !important;
+    background-color: black !important;
 }
 
 :focus {
@@ -18,7 +18,7 @@ ul.messages li.success {
 }
 
 ul.messages li {
-    border-color: black;
+    border-color: lime;
 }
 
 .dweet {
@@ -28,22 +28,22 @@ ul.messages li {
 .content-div {
     background: #001b00;
     color: lime;
-    border: 1px solid black;
+    border: 1px solid lime;
 }
 
 .content-div input {
-    border: 1px solid black;
+    border: 1px solid lime;
 }
 
 .dweet,
 .card,
 .loading,
 .end-of-feed {
-    border: 1px solid black;
+    border: 1px solid lime;
 }
 
 .submit-box {
-    border: 1px solid black;
+    border: 1px solid lime;
 }
 
 .dweet-create-form-title {
@@ -62,11 +62,11 @@ ul.messages li {
 
 .head-menu {
     background: #001000;
-    border-bottom: 1px solid #111;
+    border-bottom: 1px solid lime;
 }
 
 .head-account-info .collapsible {
-    border: 1px solid black !important;
+    border: 1px solid lime !important;
 }
 
 .head-account-info.is-logged-in:hover {
@@ -122,7 +122,7 @@ body {
 }
 
 #settings-list {
-    border: 1px solid black;
+    border: 1px solid lime;
     border-top: none;
 }
 
@@ -138,7 +138,7 @@ textarea#editor.code-input {
 .comment-section {
     background: #001b00;
     color: #00ff53;
-    border: 1px solid black;
+    border: 1px solid lime;
 }
 
 .comment-name {
@@ -147,7 +147,7 @@ textarea#editor.code-input {
 
 input,
 input[type="text"].new-dweet-comment-input {
-    border: 1px solid #3bff00;
+    border: 1px solid lime;
     background: #020e00;
     color: #3bff00;
 }
@@ -158,7 +158,7 @@ button,
 input[type="button"],
 input[type="submit"],
 .like-button {
-    border-color: #38ff00;
+    border-color: lime;
     background-color: #003100;
     /* background: #0a2b00; */
     color: #38ff00 !important;
@@ -168,7 +168,7 @@ button:hover,
 input[type="button"]:hover,
 input[type="submit"]:hover,
 .like-button:hover {
-    border-color: #38ff00;
+    border-color: lime;
     background-color: #006200;
 }
 
@@ -210,7 +210,7 @@ div.dark-section {
 }
 
 .like-button.liked {
-    border-color: #3bff00;
+    border-color: lime;
     background: #3bff00;
 }
 
@@ -219,11 +219,15 @@ div.dark-section {
 }
 
 .like-button.liked:hover {
-    border-color: #38ff00;
+    border-color: lime;
     background-color: #1a8000;
 }
 
 .record-text:hover,
 input.delete-button:hover {
     text-decoration: underline;
+}
+
+remix-info {
+    color: lime;
 }

--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -35,25 +35,27 @@
   <body class="{% block body_class %}{% endblock %}">
     <script type="text/javascript">
       // Check for compatibility
-      if (window.localStorage){
-        var switchTheme = function(){
-          // Change the imported stylesheet from main.css to main_dark.css or vice versa
-          // Change localstorage theme to 'dark'
+      if (window.localStorage) {
+        var switchTheme = function() {
+          // Shift themes
           var theme = localStorage.getItem('theme');
-          if (theme == 'dark') {
-            localStorage.setItem('theme','');
+          if (!theme) {
+            localStorage.setItem('theme', 'dark');
+          } else if (theme === 'dark') {
+            localStorage.setItem('theme', 'green');
           } else {
-            localStorage.setItem('theme','dark');
+            localStorage.setItem('theme', '');
           }
           location.reload();
           // Call this function in the li to change the mode
-        }
+        };
 
         // Do the same thing outside the function without changing localStorage to set correct theme
         var theme = localStorage.getItem('theme');
-        if (theme == 'dark'){
+        if (theme) {
           var l = document.createElement('link');
-          l.setAttribute('href', '{% static "theme_dark.css" %}');
+          if (theme === 'green') l.setAttribute('href', '{% static "theme_green.css" %}');
+          if (theme === 'dark') l.setAttribute('href', '{% static "theme_dark.css" %}');
           l.setAttribute('type', 'text/css');
           l.setAttribute('rel', 'stylesheet');
           l.setAttribute('id', 'theme-style');
@@ -61,7 +63,7 @@
         } else {
           var l = document.getElementById('theme-style');
           if (l) {
-            document.head.removeChild(l);
+            l.parentNode.removeChild(l);
           }
         }
       }
@@ -83,7 +85,7 @@
               <li><a href="{% url 'user_feed' url_username=request.user.username %}"> My profile </a></li>
               <li><a href="{% url 'user_liked' url_username=request.user.username %}"> My awesomed dweets </a></li>
               <li><a href="{% url 'user_settings' url_username=request.user.username %}"> Settings </a></li>
-              <li><a href="#" onclick="switchTheme();return false;">Switch theme</a></li>
+              <li><a href="#" onclick="switchTheme();return false;">Next theme</a></li>
               <li><a href="{% url 'password_change' %}"> Change password </a></li>
               <li><a href="{% url 'auth_logout' %}"> Log out </a></li>
             </div>

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -329,8 +329,7 @@
         };
       }
       
-      // Internet Explorer Math stuff
-      // Mostly from https://www.developer.mozilla.org
+      // Internet Explorer Math stuff, mostly from https://www.developer.mozilla.org
       let polyfills = {
         cosh: function(v) {
           return (Math.pow(Math.E, v) + Math.pow(Math.E, -v)) / 2;
@@ -413,8 +412,7 @@
       }
     }
 
-    // Remember the default globals so that later we can remove any that
-    // were created by the dweet
+    // Remember the default globals so that later we can remove any that were created by the dweet
     browserGlobals = {};
     Object.keys(window).forEach(key => {
       browserGlobals[key] = true;


### PR DESCRIPTION
See the descriptions of my commits for more details, but basically, I have:
* Restored some gray areas to the dark theme that seem to have been lost (or I don't know, it's just a bit nicer now)
* Made the green theme more visually appealing
* Passed all the CSS through not one, but *two* beautifiers, so now it's sexy af
* Fixed a little thing i saw in the comments of dweet.html (i.e that they were split)

But anyway...

I propose a green theme like this:
<pre align=center><img height=350 alt src="https://i.imgur.com/RoK8Ce8.png"></pre>
![Screenshot 2](https://i.imgur.com/81qtVrR.png)
![Screenshot 3](https://i.imgur.com/Ncv6DSt.png)
![Screenshot 4](https://i.imgur.com/971N73M.png)
![Screenshot 5](https://i.imgur.com/K5QKmK3.png)

I'll let @katkip and @lionleaf decide, but I think this looks much more user-friendly and consistent while maintaining a nice "hackery" theme. As for the theme switcher, I plan on making that a submenu or (for a more mobile-friendly solution) an external page, so we don't need to worry about that too much for now...