### PR TITLE
CSS formatting in the Makefile

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+When opening your Pull Request, we encourage you to do the following (you can add an X to check each task):
+
+- [ ] Run `make lint` to ensure that all the files are formatted and using best practices.
+- [ ] Link to any issues this PR is solving.

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ migrations:
 	python manage.py makemigrations
 
 .PHONY: lint
-lint: lint-python lint-js-fix
+lint: lint-python lint-js-fix lint-css-fix
 
 .PHONY: lint-python
 lint-python:
@@ -36,6 +36,10 @@ lint-js:
 .PHONY: lint-js-fix
 lint-js-fix:
 	npm run lint-fix -- --max-warnings 0
+
+.PHONY: lint-css-fix
+lint-css-fix:
+	npm run css-fix
 
 .PHONY: test
 test:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A twitter-style network of 140-character javascript canvas demos",
   "scripts": {
+    "css-fix": "css-beautify --replace --indent-size 2 --end-with-newline dwitter/static/*.css",
     "lint": "eslint dwitter/static/js/*.js",
     "lint-fix": "eslint --fix dwitter/static/js/*.js"
   },
@@ -20,6 +21,7 @@
     "babel-eslint": "^7.1.1",
     "eslint": "^3.17.1",
     "eslint-config-airbnb-base": "^11.1.1",
-    "eslint-plugin-import": "^2.2.0"
+    "eslint-plugin-import": "^2.2.0",
+    "js-beautify": "^1.7.5"
   }
 }


### PR DESCRIPTION
Adds `css-beautify` (part of the [`js-beautify`](https://www.npmjs.com/package/js-beautify) package).
Adds [`husky`](https://www.npmjs.com/package/husky) which lets us automatically run scripts before certain git actions.

I have not actually run the formatters on this branch, because there are outstanding PRs that would conflict.

Advantages:

- Husky will automatically run formatters (`eslint` and `css-beautify`) over the JS and CSS files whenever a `git commit` is attempted.
- It will abort the commit if `eslint` finds errors.
- It will not abort the commit if `eslint` finds only warnings. (Although the Makefile doesn't like warnings.)
- Developers can run formatting manually (e.g. before they commit) by typing: `npm run precommit`

Disadvantages:
- If the formatters do change the files, the commit will go ahead with whatever was staged _before_ (not with the newly formatted files!)
  In that case, the developer should add the formatting changes, and use `git commit --amend` to merge them into their previous commit.

- Sometimes `husky`'s hooks don't work 100%. (For example, a minority of nvm users have a prefix problem, myself included.)
  In this case, developers can bypass the formatting by using `git commit --no-verify`

- I am concerned that my script `npm run lint-fix && npm run css-fix` will fail on Windows.

- Currently multiple CSS selectors are kept on the same line, separated by `,`s. After this merge, `css-beautify` will separate them onto multiple lines. I couldn't find any way to stop that. (Actually I quite like them on separate lines anyway!)

- I have not added any formatting for HTML (template) files, or for the Javascript embedded inside them.
  We could try something like this in future:
    ```sh
    npm run html-beautify --replace --indent-size 2 --end-with-newline dwitter/templates/*.html dwitter/templates/*/*.html
    ```