### PR TITLE
Change first comment placeholder text

### DIFF
--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -101,7 +101,7 @@
             {% if not embed %}
             {% if request.user.is_authenticated %}
             <div class=post-dweet-div>
-                <input type=text placeholder="Comment" name="first-comment" class="new-dweet-comment-input" />
+                <input type=text placeholder="Add a caption..." name="first-comment" class="new-dweet-comment-input" />
                 <input
                     class="remix-button"
                     type="submit"

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -38,7 +38,7 @@ x.fillRect(400+i*100+S(t)*300,400,50,200) // draw 50x200 rects</textarea>
       <div class=dweet-changed>
       {% if request.user.is_authenticated %}
         <div class=post-dweet-div>
-        <input type=text placeholder="Comment" name="first-comment" class="new-dweet-comment-input" />
+        <input type=text placeholder="Add a caption..." name="first-comment" class="new-dweet-comment-input" />
         <input
           class=dweet-button
           type="submit"


### PR DESCRIPTION
<img width="666" alt="screen shot 2018-08-20 at 8 27 01 pm" src="https://user-images.githubusercontent.com/610925/44373516-9de80880-a4b7-11e8-9722-d73c04692fd2.png">


As suggested by @joeytwiddle I'd like to change the placeholder in the new "first comment" text field from `Comment` to something else. Rather than having the discussion in an issue, I made a pull request and we can discuss here.

My current suggestion is `Add a caption... (optional)`, but I'm open to changing it.

Some other alternatives:
<img width="197" alt="screen shot 2018-08-20 at 8 32 54 pm" src="https://user-images.githubusercontent.com/610925/44373640-3e3e2d00-a4b8-11e8-9811-d6f58b1e60fd.png">
<img width="155" alt="screen shot 2018-08-20 at 8 32 22 pm" src="https://user-images.githubusercontent.com/610925/44373644-4007f080-a4b8-11e8-907e-04e30a44a89c.png">
<img width="150" alt="screen shot 2018-08-20 at 8 31 59 pm" src="https://user-images.githubusercontent.com/610925/44373646-41391d80-a4b8-11e8-81e6-ccb87ced90bd.png">
<img width="171" alt="screen shot 2018-08-20 at 8 31 36 pm" src="https://user-images.githubusercontent.com/610925/44373648-44cca480-a4b8-11e8-85fb-77e91504521d.png">
<img width="210" alt="screen shot 2018-08-20 at 8 31 08 pm" src="https://user-images.githubusercontent.com/610925/44373650-47c79500-a4b8-11e8-9b4c-94323eb66090.png">


I think the word choice here will have a decent impact on what kind of comments we will get.
I like `caption` because it suggests both a title and/or a description.

Thoughts? 