### PR TITLE
Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python:
       - "2.7"
       - "3.6"
-matrix:
-      allow_failures:
-            - python: "3.6"
 sudo: false
 install:
       - make setup

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Inspired by [arkt.is/t/](http://arkt.is/t/Yy53aWR0aD0yZTM7eC5maWxsUmVjdCgxNTAsMT
 8. Make sure http://dweet.localhost:8000/ returns a django error. May not work in Firefox.
 
 #### **Windows**
-1. Download the latest [python2.7 release]("https://www.python.org/download/releases/2.7/").
-2. Without installing the setup, extract all the files in the a new directory such as `./python27`
-3. Set up virtual environment using the extracted interpreter: `virtualenv --python ./python27/python.exe venv`
+1. Download the latest [python3.7 release]("https://www.python.org/downloads/windows/").
+2. Without installing the setup, extract all the files in the a new directory such as `./python37`
+3. Set up virtual environment using the extracted interpreter: `virtualenv --python ./python37/python.exe venv`
 4. Activate the venv: `cd venv/Scripts && activate.bat`
 5. Get back in the main directory (`cd ../.. && make`) and use `make` command (install dependencies and set up database)
 6. Continue with the fourth step from **Linux setup**.

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -52,7 +52,7 @@ class Dweet(models.Model):
         self.calculate_hotness((self.pk is None))
         super(Dweet, self).save(*args, **kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return 'd/' + str(self.id) + ' (' + self.author.username + ')'
 
     def calculate_hotness(self, is_new):
@@ -96,7 +96,7 @@ class Comment(models.Model):
     class Meta:
         ordering = ('-posted',)
 
-    def __unicode__(self):
+    def __str__(self):
         return ('c/' +
                 str(self.id) +
                 ' (' +
@@ -109,7 +109,7 @@ class Hashtag(models.Model):
     name = models.CharField(max_length=30, unique=True, db_index=True)
     dweets = models.ManyToManyField(Dweet, related_name="hashtag", blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return '#' + self.name
 
 

--- a/dwitter/tests/dweet/test_dweet_comments.py
+++ b/dwitter/tests/dweet/test_dweet_comments.py
@@ -33,7 +33,7 @@ class DweetTestCase(TransactionTestCase):
     def get_dweet(self):
         response = self.client.get('/d/%d' % self.dweet.id)
         self.assertEqual(response.status_code, 200)
-        return response.content
+        return response
 
     def get_comments_ajax(self):
         response = self.client.get('/api/comments/?format=json&reply_to=%d' % self.dweet.id)
@@ -43,24 +43,24 @@ class DweetTestCase(TransactionTestCase):
     def test_comment(self):
         comment = self.create_comment('this is a comment!')
         response = self.get_dweet()
-        self.assertIn(comment.text, response)
+        self.assertContains(response, comment.text)
 
     def test_comment_xss(self):
         comment = self.create_comment('<test>this is a comment!</test>')
         response = self.get_dweet()
-        self.assertNotIn('<test>', response)
-        self.assertIn(escape(comment.text), response)
+        self.assertNotContains(response, '<test>')
+        self.assertContains(response, escape(comment.text))
 
     def test_comment_code_blocks(self):
         comment = self.create_comment('`this is a comment!`')
         response = self.get_dweet()
-        self.assertIn(code_wrap(comment.text), response)
+        self.assertContains(response, code_wrap(comment.text))
 
     def test_comment_code_blocks_xss(self):
         comment = self.create_comment('`<test>this is a comment!</test>`')
         response = self.get_dweet()
-        self.assertNotIn('<test>', response)
-        self.assertIn(code_wrap(escape(comment.text)), response)
+        self.assertNotContains(response, '<test>')
+        self.assertContains(response, code_wrap(escape(comment.text)))
 
     def test_comment_ajax(self):
         comment = self.create_comment('this is a comment!')

--- a/dwitter/tests/dweet/test_dweet_views.py
+++ b/dwitter/tests/dweet/test_dweet_views.py
@@ -42,7 +42,7 @@ class DweetTestCase(TransactionTestCase):
                        view=fullscreen_dweet,
                        status_code=200,
                        templates=['dweet/dweet.html'])
-        self.assertIn(wrap_content(self.dweet.code), response.content)
+        self.assertContains(response, wrap_content(self.dweet.code))
 
     def test_blank_dweet_renders_with_correct_template(self):
         response = self.client.get('/blank')
@@ -50,4 +50,4 @@ class DweetTestCase(TransactionTestCase):
                        view=blank_dweet,
                        status_code=200,
                        templates=['dweet/dweet.html'])
-        self.assertIn(wrap_content(response.context['code']), response.content)
+        self.assertContains(response, wrap_content(response.context['code']))

--- a/dwitter/tests/models/test_comment.py
+++ b/dwitter/tests/models/test_comment.py
@@ -37,9 +37,9 @@ class DweetTestCase(TestCase):
                                author=user2)
 
     def test_comment_renders_to_string_correctly(self):
-        self.assertEqual(Comment.objects.get(id=1).__unicode__(),
+        self.assertEqual(Comment.objects.get(id=1).__str__(),
                          "c/1 (user1) to d/2 (user2)")
-        self.assertEqual(Comment.objects.get(id=2).__unicode__(),
+        self.assertEqual(Comment.objects.get(id=2).__str__(),
                          "c/2 (user2) to d/1 (user1)")
 
     def test_comment_reply_to_do_nothing_on_soft_delete(self):

--- a/dwitter/tests/models/test_dweet.py
+++ b/dwitter/tests/models/test_dweet.py
@@ -26,8 +26,8 @@ class DweetTestCase(TestCase):
         dweet2.likes.add(user1, user2)
 
     def test_dweet_renders_to_string_correctly(self):
-        self.assertEqual(Dweet.objects.get(id=1).__unicode__(), "d/1 (user1)")
-        self.assertEqual(Dweet.objects.get(id=2).__unicode__(), "d/2 (user2)")
+        self.assertEqual(Dweet.objects.get(id=1).__str__(), "d/1 (user1)")
+        self.assertEqual(Dweet.objects.get(id=2).__str__(), "d/2 (user2)")
 
     def test_dweet_reply_to_set_deleted_field_on_delete(self):
         dweet1 = Dweet.objects.get(id=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ django-subdomains==2.1.0rc0
 django==1.8.14
 djangorestframework==3.3.3
 flake8==2.6.2
-newrelic==2.98.0.81
+newrelic==4.2.0.100
 django-cors-headers==2.4.0


### PR DESCRIPTION
- [x] Run `make lint` to ensure that all the files are formatted and using best practices.

I did this, but it caused changes in files I haven't touched, so I assume they are currently not linted properly on master

- [x] Link to any issues this PR is solving.

No open issues for python3 support that I could find.

---

I haven't extensively tried to test or check that all third-party packages work with this, but new relic was the only one that caused errors upon boot.
One remaining thing that may be done is to run the server locally with deprecation warnings enabled, to see if something should be changed.

We might want to make some more changes to the readme to explain that python3 is required instead of python2.