### PR TITLE
Shorter HSLA function.

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -202,9 +202,14 @@
     var S = Math.sin;
     var C = Math.cos;
     var T = Math.tan;
-    function R(r,g,b,a) {
+    function R(r, g, b, a) {
       a = a === undefined ? 1 : a;
       return "rgba("+(r|0)+","+(g|0)+","+(b|0)+","+a+")";
+    }
+    function H(h, s, l, a)
+    {
+      a = a === undefined ? 1 : a;
+      return `hsla(${h}, ${s}%, ${l}%, ${a})`
     }
   
     var time = 0;

--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -74,6 +74,8 @@
       C: Math.cos
       T: Math.tan
       R: Generates rgba-strings, ex.: R(255, 255, 255, 0.5)
+      H: Generates hsla-strings, ex.: H(60, 95%, 65%, 0.8)
+}
     </code>
     </div>
   {% endif %}

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -56,6 +56,7 @@ x.fillRect(400+i*100+S(t)*300,400,50,200) // draw 50x200 rects</textarea>
     C: Shorthand for Math.cos.
     T: Shorthand for Math.tan.
     R: Function that generates rgba-strings, usage ex.: R(255, 255, 255, 0.5)
+    H: Function that generates hsla-strings, usage ex.: H(60, 95%, 65%, 0.8)
     c: A 1920x1080 canvas.
     x: A 2D context for that canvas.
   </code>


### PR DESCRIPTION
We already have the rgba function but why don't have a hsla function that is very used.
```js
x.fillStyle = `hsla(${t*i},99%,50%,0.4)` // H(orrible)

x.fillStyle = H(t*i,99,50,0.4) // awesome!
```

It works like the R function.
```js
 function H(h, s, l, a)
 {
    a = a === undefined ? 1 : a;
    return `hsla(${h}, ${s}%, ${l}%, ${a})`
 }
```