### PR TITLE
Fix Expired Discord URL in About Page

### DIFF
--- a/dwitter/templates/about.html
+++ b/dwitter/templates/about.html
@@ -61,7 +61,7 @@ About | Dwitter
 
     <br />
     <p>
-    Please join us in the <a href="https://discord.gg/YxTPFd">discord chat</a> to hang out, ask for coding help, or discuss anything :D If you don't know where to start and want to learn, this is the perfect place to start. See you there!
+    Please join us in the <a href="https://discord.gg/s6GVjX3">discord chat</a> to hang out, ask for coding help, or discuss anything :D If you don't know where to start and want to learn, this is the perfect place to start. See you there!
     </p>
 
     <a


### PR DESCRIPTION
This is a fairly self-explanatory commit.  Fixes issue #397.