### PR TITLE
Clean up all discord links and remove discord widget

### DIFF
--- a/dwitter/templates/about.html
+++ b/dwitter/templates/about.html
@@ -61,41 +61,13 @@ About | Dwitter
 
     <br />
     <p>
-    Please join us in the <a href="https://discord.gg/s6GVjX3">discord chat</a> to hang out, ask for coding help, or discuss anything :D If you don't know where to start and want to learn, this is the perfect place to start. See you there!
+    Please join us in the <a href="https://discord.gg/emHe6cP">discord chat</a> to hang out, ask for coding help, or discuss anything :D If you don't know where to start and want to learn, this is the perfect place to start. See you there!
     </p>
 
-    <a
-      style="
-        display: block;
-        max-width: 360px;
-        height: 74px;
-        margin: 32px auto 16px;
-        position: relative;
-      "
-      href="https://discord.gg/r5nXDsQ"
-    >
-      <iframe
-        src="https://discordapp.com/widget?id=395956681793863690&theme=dark"
-        style="
-          height: 100%;
-          width: 100%;
-          position: absolute;
-        "
-        allowtransparency="true"
-        frameborder="0"
-        >
-      </iframe>
-      <div style="
-        height: 100%;
-        width: 100%;
-        position: absolute;
-      ">
-      </div>
-    </a>
-
     <br />
+
     <p>
-    <b>Contact</b> <br/> <em>andreas.l.selvik@gmail.com</em> and <em>sigvefarstad@gmail.com</em> or <b>@lionleaf</b> and <b>@sigveseb</b> on <a href="https://discord.gg/YxTPFd">discord</a>
+    <b>Contact</b> <br/> <em>andreas.l.selvik@gmail.com</em> and <em>sigvefarstad@gmail.com</em> or <b>@lionleaf</b> and <b>@sigveseb</b> on <a href="https://discord.gg/emHe6cP">discord</a>
     </p>
 
 


### PR DESCRIPTION
Removing the discord widget, it is served from an iframe and I would
have to enable iframe sources from discord, something I don't want
dweets to have. I could probably have separate CSP for /about but it's
easier to remove it.

Also moved all links to the same invite code that should be valid (I
think one of them were broken)

From:
<img width="721" alt="screen shot 2018-10-13 at 10 09 26 pm" src="https://user-images.githubusercontent.com/610925/46912814-d72b7a80-cf34-11e8-98bd-f95075d83f82.png">



To: 
<img width="675" alt="screen shot 2018-10-13 at 10 09 38 pm" src="https://user-images.githubusercontent.com/610925/46912817-dabf0180-cf34-11e8-8aa3-118f51ebd612.png">
