### PR TITLE
Fix the TypeError: 'u' is not a function

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -131,6 +131,9 @@
       function newCode(code) {
           window.stopper.reset();
           try {
+            // Using new Function(), if the code reassigns `u`, it will reassign the global, breaking the dweet
+            //var u = new Function("t", instrument(code));
+            // Using eval(), if the code reassigns `u`, it will reassign the local, leaving `window.u` working
             eval("function u(t) {\n"+instrument(code)+"\n}");
             window.u = u;
           } catch (e) {
@@ -214,14 +217,14 @@
   
     var time = 0;
     var frame = 0;
-    
+
     function u(t) {
       {{ code | safe }}
     }
-    
-    let src = (u + "").replace(/(function u\(t\) {|}$)/g, "");
-    u = new Function("t", instrument(src));
-    
+
+    var src = (u + "").replace(/(function u\(t\) {|}$)/g, "");
+    newCode(src);
+
     function loop() {
       stats = stats || createStats();
 


### PR DESCRIPTION
When writing using the "New Dweet" button, reassigning `u` does not break the dweet, because `newCode()` has created a local `u` which is what gets reassigned. The global `window.u` remains intact, and so the dweet can keep running.

But when loading dweets **from the feed**, `newCode()` is not called. `u` is creating in the top level function, so overwriting `u` will lead to the popular error message:

> `TypeError: 'u' is not a function`

The solution offered here, it to call `newCode()` for feed dweets, like we do for edited dweets.

(I did try using `new Function()` inside there, but that type of function [executes in the global scope](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function), not the scope it was created in, so it went back to overwriting the global `u`! I switched back to `eval()` and documented the reason why.)

## Disadvantages

- If any of the existing dweets overwrite `u` on purpose with a working function, to do something amazing, then this PR will stop them from working.
  I can't think of any instances of that, but if anyone does, please let us know! @sigvef or @iver56 or @stianjensen or @BalintCsala 

## More boring details

- Apparently the behaviour of having a local `u` in `newCode()` is not that old. It looks like it was introduced here: https://github.com/lionleaf/dwitter/pull/299/files

- We call `window.u()` on each frame. A better solution would be to use a local variable such as `var functionWeWillRunEachFrame`, held inside the scope of a function, so the dweet cannot harm it. This way we could safely switch from `eval()` to `new Function()`.

  However, that would require a significant change to the code. And the more lines I change, the more portals to the netherworld will be unintentionally opened. So I didn't do that.