### PR TITLE
Update django-dbbackup for 1.11 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto==2.42
 django-anymail==4.3
 django-compressor==2.2
 django-cors-headers==2.4.0
-django-dbbackup==3.0.2
+django-dbbackup==3.2.0
 django-debug-toolbar==1.9.1
 django-filter==1.1
 django-hosts==3.0


### PR DESCRIPTION
Backups broke with the 1.11 upgrade :) Already fixed in prod and backups are happening every hour, this pulls that into master
