### PR TITLE
Change the comment default ordering to a more natural order

### DIFF
--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -111,7 +111,7 @@ class Comment(models.Model):
     author = models.ForeignKey(User, on_delete=models.CASCADE)
 
     class Meta:
-        ordering = ('-posted',)
+        ordering = ('posted',)
 
     def __str__(self):
         return ('c/' +

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -52,6 +52,15 @@ class Dweet(models.Model):
         self.calculate_hotness((self.pk is None))
         super(Dweet, self).save(*args, **kwargs)
 
+    @property
+    def sticky_comment(self):
+        """
+        True when first comment should be stickied (first comment author == dweet author)
+        """
+        if self.comments.last() is None:
+            return False
+        return self.comments.last().author == self.author
+
     def __str__(self):
         return 'd/' + str(self.id) + ' (' + self.author.username + ')'
 

--- a/dwitter/static/js/ajax-handling.js
+++ b/dwitter/static/js/ajax-handling.js
@@ -38,24 +38,17 @@ function getCommentHTML(comment) {
 }
 
 function loadComments() {
-  var step = 1000;
-  var currentOffset = $(this).data('offset');
-
   var $loadCommentsButton = $(this);
 
   var dweetId = $loadCommentsButton.data('dweet_id');
-  // If there is a sticky comment on the top of the comments
-  var stickyTop = $loadCommentsButton.data('sticky_top');
+  var offset = $loadCommentsButton.data('hidden_comments_offset');
+  var limit = $loadCommentsButton.data('hidden_comments_number');
 
   var loadCommentsResponse = function(response) {
     var commentSection = $loadCommentsButton.parents('.comments')[0];
-    var newCommentList = response.results.reverse().map(function(comment, index) {
-      return stickyTop && index === 0 ? '' : getCommentHTML(comment);
-    }).join('');
+    var newCommentList = response.results.map(getCommentHTML).join('');
 
-    if (!response.next) {
-      $loadCommentsButton.parents('.comment').hide();
-    }
+    $loadCommentsButton.parents('.comment').hide();
 
     $(commentSection)
       .html(newCommentList + commentSection.innerHTML)
@@ -64,8 +57,8 @@ function loadComments() {
   };
 
   var config = {
-    url: '/api/comments/?offset=' + currentOffset +
-         '&limit=' + step +
+    url: '/api/comments/?offset=' + offset +
+         '&limit=' + limit +
          '&format=json&reply_to=' + dweetId,
     dataType: 'json',
     success: loadCommentsResponse,

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -117,20 +117,20 @@
   </div>
   {% if not embed %}
   <div class=comment-section>
-    {% if dweet.comments.last.author == dweet.author %}
+    {% if dweet.has_sticky_comment %}
     <ul class=sticky-comments>
       <li class="comment sticky-comment">
-        <a class="comment-name sticky-comment" href="{% url 'user_feed' url_username=dweet.comments.last.author.username %}">{{ dweet.comments.last.author.username }}:</a>
-        <span class="comment-message sticky-comment">{{ dweet.comments.last.text | force_escape | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
+        <a class="comment-name sticky-comment" href="{% url 'user_feed' url_username=dweet.top_comment.author.username %}">{{ dweet.top_comment.author.username }}:</a>
+        <span class="comment-message sticky-comment">{{ dweet.top_comment.text | force_escape | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
       </li>
     </ul>
     {% endif %}
     <ul class=comments>
-      {% if dweet.comments.count > 3 and not dweet.sticky_comment or dweet.comments.count > 4 %}
+      {% if dweet.comments.count > 3 and not dweet.has_sticky_comment or dweet.comments.count > 4 %}
       <li class=comment>
       <a href="javascript:;" class="load-comments-link"
                              data-dweet_id="{{ dweet.id }}"
-                             {% if dweet.comments.last.author == dweet.author %}
+                             {% if dweet.has_sticky_comment %}
                              data-sticky_top="1"
                              {% endif %}
                              data-offset=3>
@@ -138,7 +138,7 @@
       </li>
       {% endif %}
       {% for comment in dweet.comments.all|slice:"3" reversed %}
-      {% if comment != dweet.comments.last or dweet.comments.last.author != dweet.author  %}
+      {% if comment != dweet.top_comment or not dweet.has_sticky_comment  %}
       <li class=comment>
       <a class=comment-name href="{% url 'user_feed' url_username=comment.author.username %}">{{ comment.author.username }}:</a>
       <span class="comment-message">{{ comment.text | force_escape | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -123,10 +123,10 @@
         <a class="comment-name sticky-comment" href="{% url 'user_feed' url_username=dweet.comments.last.author.username %}">{{ dweet.comments.last.author.username }}:</a>
         <span class="comment-message sticky-comment">{{ dweet.comments.last.text | force_escape | insert_code_blocks | urlizetrunc:45 | insert_magic_links }}</span>
       </li>
-      </ul>
-        {% endif %}
-        <ul class=comments>
-      {% if dweet.comments.count > 3 %}
+    </ul>
+    {% endif %}
+    <ul class=comments>
+      {% if dweet.comments.count > 3 and not dweet.sticky_comment or dweet.comments.count > 4 %}
       <li class=comment>
       <a href="javascript:;" class="load-comments-link"
                              data-dweet_id="{{ dweet.id }}"

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -131,13 +131,16 @@
       <a href="javascript:;" class="load-comments-link"
                              data-dweet_id="{{ dweet.id }}"
                              {% if dweet.has_sticky_comment %}
-                             data-sticky_top="1"
-                             {% endif %}
-                             data-offset=3>
+                             data-hidden_comments_offset=1
+                             data-hidden_comments_number={{ dweet.comments.count|add:"-4" }}
+                             {% else %}
+                             data-hidden_comments_offset=0
+                             data-hidden_comments_number={{ dweet.comments.count|add:"-3" }}
+                             {% endif %}>
         Load older comments...</a>
       </li>
       {% endif %}
-      {% for comment in dweet.comments.all|slice:"3" reversed %}
+      {% for comment in dweet.comments.all|dictsortreversed:"posted"|slice:"3" reversed %}
       {% if comment != dweet.top_comment or not dweet.has_sticky_comment  %}
       <li class=comment>
       <a class=comment-name href="{% url 'user_feed' url_username=comment.author.username %}">{{ comment.author.username }}:</a>


### PR DESCRIPTION
In changing the comment loading, I realized the ordering was reversed
as a trick to make it easier to slice the newest comments off at the
end. But I think ordering in the order intended for display makes more
sense and I've solved the slicing issues

(based on #403, so merge afterwards)

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.

