### PR TITLE
Add an epsilon to the frame timing check

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -232,7 +232,8 @@
 
       if (playing){
         requestAnimationFrame(loop);
-        if (frame_time < Math.floor(nextFrameMs)) {
+        epsilon = 1.5; // Acounts for different timestamp resolution and slight jitter
+        if (frame_time < nextFrameMs - epsilon) {
           return;  // Skip this cycle as we are animating too quickly.
         }
         nextFrameMs = Math.max(nextFrameMs + 1000 / FPS, frame_time);

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -227,16 +227,15 @@
     var src = (u + "").replace(/(function u\(t\) {|}$)/g, "");
     newCode(src);
 
-    function loop() {
+    function loop(frame_time) {
       stats = stats || createStats();
 
       if (playing){
         requestAnimationFrame(loop);
-        var now = new Date().getTime();
-        if (now < nextFrameMs) {
+        if (frame_time < Math.floor(nextFrameMs)) {
           return;  // Skip this cycle as we are animating too quickly.
         }
-        nextFrameMs = Math.max(nextFrameMs + 1000 / FPS, now);
+        nextFrameMs = Math.max(nextFrameMs + 1000 / FPS, frame_time);
       }
       time = frame/FPS;
       if(time * FPS | 0 == frame - 1){
@@ -289,7 +288,7 @@
       }
     }
     if(autoplay) {
-        loop();
+        loop(0.0);
     }
 
     function reset(){


### PR DESCRIPTION
I was getting frame timeouts when the time was off by 0.3ms etc.
This change also uses the timing passed in by requestAnimationFrame
rather than Date.now. This should be more stable as this is a time
that is sampled just before the browser starts doing all the redraws,
so it doesn't depend on how much compute has been done before the
dweet callback is called.

I think.

I am getting some frame skipping on my macbook even with this, but from the timing of them I think they must be requestAnimationFrame triggering extra frames when scrolling or something.


- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.

#414 #415 
