### PR TITLE
Send message to Discord with a webhook upon dweet creation

### DIFF
--- a/dwitter/__init__.py
+++ b/dwitter/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'dwitter.apps.DwitterConfig'

--- a/dwitter/apps.py
+++ b/dwitter/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class DwitterConfig(AppConfig):
+    name = 'dwitter'
+
+    def ready(self):
+        # Register signals
+        import dwitter.signals  # noqa: F401

--- a/dwitter/signals.py
+++ b/dwitter/signals.py
@@ -1,0 +1,10 @@
+from django.dispatch import receiver
+from django.db.models.signals import post_save
+from .models import Dweet
+from .webhooks import Webhooks
+
+
+@receiver(post_save, sender=Dweet, dispatch_uid="new_dweet_notifications_signal")
+def new_dweet_notifications(sender, instance, created, **kwargs):
+    if(created):
+        Webhooks.new_dweet_notifications(instance)

--- a/dwitter/webhooks.py
+++ b/dwitter/webhooks.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 import json
-import urllib2
+# Support for python3 and 2.7
+from future.standard_library import install_aliases
+install_aliases()
+from urllib.request import urlopen, Request  # noqa: E402
 
 
 class Webhooks:
@@ -11,10 +14,10 @@ class Webhooks:
         post_data = {'content': message}
 
         # A User-Agent string is required, so I'm just making one up
-        req = urllib2.Request(settings.DISCORD_WEBHOOK, json.dumps(post_data),
-                              {'Content-Type': 'application/json', 'User-Agent': 'Dwitter/1.0'})
+        req = Request(settings.DISCORD_WEBHOOK, json.dumps(post_data),
+                      {'Content-Type': 'application/json', 'User-Agent': 'Dwitter/1.0'})
         try:
-            f = urllib2.urlopen(req)
+            f = urlopen(req)
             f.close()
         except Exception:
             return  # Fail silently, webhooks will stop rather than breaking the site

--- a/dwitter/webhooks.py
+++ b/dwitter/webhooks.py
@@ -1,9 +1,5 @@
 from django.conf import settings
-import json
-# Support for python3 and 2.7
-from future.standard_library import install_aliases
-install_aliases()
-from urllib.request import urlopen, Request  # noqa: E402
+import requests
 
 
 class Webhooks:
@@ -11,14 +7,11 @@ class Webhooks:
     def send_discord_message(message):
         if(not hasattr(settings, 'DISCORD_WEBHOOK')):
             return  # No discord webhook set up
+
         post_data = {'content': message}
 
-        # A User-Agent string is required, so I'm just making one up
-        req = Request(settings.DISCORD_WEBHOOK, json.dumps(post_data),
-                      {'Content-Type': 'application/json', 'User-Agent': 'Dwitter/1.0'})
         try:
-            f = urlopen(req)
-            f.close()
+            requests.post(settings.DISCORD_WEBHOOK, json=post_data)
         except Exception:
             return  # Fail silently, webhooks will stop rather than breaking the site
 

--- a/dwitter/webhooks.py
+++ b/dwitter/webhooks.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.urls import reverse
 import json
 import urllib2
 
@@ -23,9 +22,9 @@ class Webhooks:
     @staticmethod
     def new_dweet_notifications(dweet):
         authorname = dweet.author.username
-        msg = ('[u/%s](https://www.dwitter.net%s) posted new dweet ' %
-               (authorname, reverse('user_feed', args=[authorname])) +
-               '[d/%d](https://www.dwitter.net%s):\n```js\n%s\n```' %
-               (dweet.id, reverse('dweet_show', args=[dweet.id]), dweet.code))
+        msg = ('[u/%s](https://www.dwitter.net/u/%s) posted new dweet ' %
+               (authorname, authorname) +
+               '[d/%d](https://www.dwitter.net/d/%s):\n```js\n%s\n```' %
+               (dweet.id, dweet.id, dweet.code))
 
         Webhooks.send_discord_message(msg)

--- a/dwitter/webhooks.py
+++ b/dwitter/webhooks.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from django.urls import reverse
+import json
+import urllib2
+
+
+class Webhooks:
+    @staticmethod
+    def send_discord_message(message):
+        if(not hasattr(settings, 'DISCORD_WEBHOOK')):
+            return  # No discord webhook set up
+        post_data = {'content': message}
+
+        # A User-Agent string is required, so I'm just making one up
+        req = urllib2.Request(settings.DISCORD_WEBHOOK, json.dumps(post_data),
+                              {'Content-Type': 'application/json', 'User-Agent': 'Dwitter/1.0'})
+        try:
+            f = urllib2.urlopen(req)
+            f.close()
+        except Exception:
+            return  # Fail silently, webhooks will stop rather than breaking the site
+
+    @staticmethod
+    def new_dweet_notifications(dweet):
+        authorname = dweet.author.username
+        msg = ('[u/%s](https://www.dwitter.net%s) posted new dweet ' %
+               (authorname, reverse('user_feed', args=[authorname])) +
+               '[d/%d](https://www.dwitter.net%s):\n```js\n%s\n```' %
+               (dweet.id, reverse('dweet_show', args=[dweet.id]), dweet.code))
+
+        Webhooks.send_discord_message(msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ django-storages-redux==1.3.2
 django==1.11.15
 djangorestframework==3.7.1
 flake8==2.6.2
-future==0.17.0
 newrelic==4.2.0.100

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ django-storages-redux==1.3.2
 django==1.11.15
 djangorestframework==3.7.1
 flake8==2.6.2
+future==0.17.0
 newrelic==4.2.0.100


### PR DESCRIPTION
Register a signal that triggers on new dweets that sends a POST request
to the configured DISCORD_WEBHOOK (from settings/local.py) that posts a
message to Discord.

This commit also sets up the signals.py file and imports it with the
recommended path (apps.py).

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.

fixes #370 