### PR TITLE
Fix title of dweet-pages after comment reordering broke them

### DIFF
--- a/dwitter/templates/feed/embed.html
+++ b/dwitter/templates/feed/embed.html
@@ -8,8 +8,8 @@
             Embedded - deleted dweet | Dwitter
             {% else %}
             Embedded -
-            {% if dweet.comments.last.author == dweet.author %}
-            {{ dweet.comments.last.text | truncatechars:40 }}
+            {% if dweet.has_sticky_comment %}
+              {{ dweet.comments.first.text | truncatechars:40 }}
             {% else %}
             d/{{ dweet.id }}
             {% endif %}

--- a/dwitter/templates/feed/permalink.html
+++ b/dwitter/templates/feed/permalink.html
@@ -17,8 +17,8 @@
   {% if dweet.deleted %}
     Deleted dweet - Dwitter
   {% else %}
-    {% if dweet.comments.last.author == dweet.author %}
-      {{ dweet.comments.last.text | truncatechars:40 }}
+    {% if dweet.has_sticky_comment %}
+      {{ dweet.comments.first.text | truncatechars:40 }}
     {% else %}
       d/{{ dweet.id }}
     {% endif %}


### PR DESCRIPTION
- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.