### PR TITLE
Add feeds for top week/month/year/all-time

### DIFF
--- a/dwitter/feed/urls.py
+++ b/dwitter/feed/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 from . import views
-from .views import HotDweetFeed, TopDweetFeed, NewDweetFeed, RandomDweetFeed
+from .views import HotDweetFeed, NewDweetFeed, RandomDweetFeed
+from .views import TopWeekDweetFeed, TopMonthDweetFeed, TopYearDweetFeed, TopAllDweetFeed
 from .views import NewHashtagFeed, TopHashtagFeed
 
 urlpatterns = [
@@ -8,7 +9,14 @@ urlpatterns = [
 
     url(r'^$', HotDweetFeed.as_view(), name='root'),
     url(r'^hot$', HotDweetFeed.as_view(), name='hot_feed'),
-    url(r'^top$', TopDweetFeed.as_view(), name='top_feed'),
+
+    # Default top to top of the month
+    url(r'^top$', TopMonthDweetFeed.as_view(), name='top_feed'),
+    url(r'^top/week$', TopWeekDweetFeed.as_view(), name='top_feed_week'),
+    url(r'^top/month$', TopMonthDweetFeed.as_view(), name='top_feed_month'),
+    url(r'^top/year$', TopYearDweetFeed.as_view(), name='top_feed_year'),
+    url(r'^top/all$', TopAllDweetFeed.as_view(), name='top_feed_all'),
+
     url(r'^new$', NewDweetFeed.as_view(), name='new_feed'),
     url(r'^random$', RandomDweetFeed.as_view(), name='random_feed'),
 

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -475,6 +475,7 @@ iframe {
   transition: opacity .1s ease-in-out, margin .1s step-end;
   opacity: 0;
   height: 0;
+  margin-top: -9999px;  /* remove the hover-trigger while invisible */
 }
 
 .top-sort-list li:hover>.collapsible,
@@ -483,6 +484,7 @@ iframe {
   display: block;
   opacity: 1;
   transition: opacity .1s ease-in-out, margin .1s step-start;
+  margin-top: 0;
 }
 
 .head-account-info .collapsible {

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -32,7 +32,7 @@
   vertical-align: middle;
 }
 
-@media (max-width: 700px) {
+@media (max-width: 735px) {
   #dwitter-header-text {
     display: none;
   }
@@ -461,6 +461,30 @@ iframe {
   }
 }
 
+
+.top-sort-list li .collapsible li {
+  display: block;
+  background: white;
+  border: 1px solid #ddd;
+  padding: 2px;
+}
+
+.top-sort-list li .collapsible {
+  position: absolute;
+  z-index: 10;
+  transition: opacity .1s ease-in-out, margin .1s step-end;
+  opacity: 0;
+  height: 0;
+}
+
+.top-sort-list li:hover>.collapsible,
+.top-sort-list li .collapsible:hover {
+  position: absolute;
+  display: block;
+  opacity: 1;
+  transition: opacity .1s ease-in-out, margin .1s step-start;
+}
+
 .head-account-info .collapsible {
   position: absolute;
   border: 1px solid #ddd;
@@ -716,6 +740,31 @@ form.like {
 }
 
 body.new .top-sort-list a.new {
+  font-weight: bold;
+}
+
+body.top-day .top-sort-list a.top-day,
+body.top-day .top-sort-list a.top {
+  font-weight: bold;
+}
+
+body.top-week .top-sort-list a.top-week,
+body.top-week .top-sort-list a.top {
+  font-weight: bold;
+}
+
+body.top-month .top-sort-list a.top-month,
+body.top-month .top-sort-list a.top {
+  font-weight: bold;
+}
+
+body.top-year .top-sort-list a.top-year,
+body.top-year .top-sort-list a.top {
+  font-weight: bold;
+}
+
+body.top-all .top-sort-list a.top-all,
+body.top-all .top-sort-list a.top {
   font-weight: bold;
 }
 

--- a/dwitter/templates/feed.html
+++ b/dwitter/templates/feed.html
@@ -20,7 +20,7 @@ Dwitter is a social network for building and sharing visual javascript demos lim
 {% endcompress %}
 {% endblock %}
 
-{% block body_class %}{{sort}}{% endblock %}
+{% block body_class %}{{feed_name}}{% endblock %}
 
 
 {% block header_title %}
@@ -41,14 +41,29 @@ Dwitter is a social network for building and sharing visual javascript demos lim
   {%if feed_type == "all" %}
   <li><a class="hot" href="{% url 'hot_feed' %}">hot</a></li>
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
-  <li><a class="top" href="{% url 'top_feed' %}">top</a></li>
+  {% if "top" in feed_name %}
+  <li style="padding:0"><a class="top" href="{% url 'top_feed_month' %}">top |</a></li>
+  <li><a class="top" href="{% url 'top_feed_month' %}">{{top_name}}</a>
+    <ul class=collapsible>
+        <li><a class="top-week" href="{% url 'top_feed_week' %}">week</a></li>
+        <li><a class="top-month" href="{% url 'top_feed_month' %}">month</a></li>
+        <li><a class="top-year" href="{% url 'top_feed_year' %}">year</a></li>
+        <li><a class="top-all" href="{% url 'top_feed_all' %}">all time</a></li>
+    </ul>
+  </li>
+  {% else %}
+  <li><a class="top" href="{% url 'top_feed_month' %}">top</a></li>
+  {% endif %}
+
   <li><a class="random" href="{% url 'random_feed' %}">random</a></li>
   <li><a class="about" href="{% url 'about' %}">about</a></li>
+
   {%elif feed_type == "user" %}
   <li><a class="hot" href="{% url 'hot_user_feed' url_username=user.username %}">hot</a></li>
   <li><a class="new" href="{% url 'user_feed' url_username=user.username %}">new</a></li>
   <li><a class="top" href="{% url 'top_user_feed' url_username=user.username %}">top</a></li>
   <li><a class="awesome" href="{% url 'user_liked' url_username=user.username %}">awesomed</a></li>
+
   {%elif feed_type == "hashtag" %}
   <li><a class="new" href="{% url 'hashtag_feed' hashtag_name=hashtag %}">new</a></li>
   <li><a class="top" href="{% url 'top_hashtag_feed' hashtag_name=hashtag %}">top</a></li>

--- a/dwitter/tests/feed/test_user_feeds.py
+++ b/dwitter/tests/feed/test_user_feeds.py
@@ -32,6 +32,11 @@ class UserFeedTestCase():  # Not inheriting from TestCase, an abstract test clas
                 for i in range(random.randrange(0, 5)):
                     dweets[-1].likes.add(self.users[i])
 
+        # Guarantee that all users have at least two liked dweets
+        for i in range(10):
+            dweets[0].likes.add(self.users[i])
+            dweets[2].likes.add(self.users[i])
+
     def test_all_dweet_author(self):
         self.dweetFeed.kwargs = {'url_username': self.users[3].username}
         queryset = self.dweetFeed.get_queryset()


### PR DESCRIPTION
Add 4 variants of the top feed; top of the week (last 7 days),
top of the month (last 30 days), top of the year (last 365 days)
and top of all time (the old top behaviour).

Also adds a dropdown menu to select between the new feeds.

And adds new unit tests.
<img width="422" alt="screen shot 2018-11-25 at 11 16 33 pm" src="https://user-images.githubusercontent.com/610925/48992865-2d7d0300-f108-11e8-80ca-813c67eef465.png">
<img width="484" alt="screen shot 2018-11-25 at 11 08 23 pm" src="https://user-images.githubusercontent.com/610925/48992679-299cb100-f107-11e8-9b6f-114f5794b815.png">
<img width="580" alt="screen shot 2018-11-25 at 11 08 29 pm" src="https://user-images.githubusercontent.com/610925/48992673-1f7ab280-f107-11e8-8788-3bfb9d73edce.png">
<img width="190" alt="screen shot 2018-11-25 at 11 08 43 pm" src="https://user-images.githubusercontent.com/610925/48992675-21447600-f107-11e8-80e3-bbab72d8ccbb.png">

Default top feed is "top of the month", which will hopefully be more dynamic than top of all time.

Note; I made a conscious decision to pick a handful of specific feeds (`top/week`, `top/month`, `top/year`, `top/all`) rather than a more flexible url-parameter (eg. `top?days=23`). This gives us fewer "official" rankings with nice URLs that the whole community get the same small handful of lists. I know it's easy to want full configurability; but I'm opting to keep things simple for now :D 

Would be great to get some feedback on the code :)