### PR TITLE
Remove wrong href in top category dropdown menu

### DIFF
--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -485,8 +485,8 @@ iframe {
   z-index: 10;
   transition: opacity .1s ease-in-out, margin .1s step-end;
   opacity: 0;
-  margin-top: -9999px;
   /* remove the hover-trigger while invisible */
+  margin-top: -9999px;
   border: 1px solid #ddd;
 }
 

--- a/dwitter/static/main.css
+++ b/dwitter/static/main.css
@@ -469,9 +469,11 @@ iframe {
   line-height: normal;
   padding: 0;
 }
+
 .top-sort-list li .collapsible li:last-child {
   border: none;
 }
+
 .top-sort-list li .collapsible li a {
   width: 100px;
   padding: 14px;
@@ -483,7 +485,8 @@ iframe {
   z-index: 10;
   transition: opacity .1s ease-in-out, margin .1s step-end;
   opacity: 0;
-  margin-top: -9999px;  /* remove the hover-trigger while invisible */
+  margin-top: -9999px;
+  /* remove the hover-trigger while invisible */
   border: 1px solid #ddd;
 }
 
@@ -511,6 +514,7 @@ iframe {
   margin: -5px 0 -5px 5px;
   padding: 5px;
 }
+
 .head-account-info.is-logged-in:hover {
   background: #ddd;
 }
@@ -528,6 +532,7 @@ iframe {
   border-bottom: 1px solid #ddd;
   line-height: normal;
 }
+
 .head-account-info .collapsible li:last-child {
   border: none;
 }

--- a/dwitter/templates/feed.html
+++ b/dwitter/templates/feed.html
@@ -43,7 +43,7 @@ Dwitter is a social network for building and sharing visual javascript demos lim
   <li><a class="new" href="{% url 'new_feed' %}">new</a></li>
   {% if "top" in feed_name %}
   <li style="padding:0"><a class="top" href="{% url 'top_feed_month' %}">top |</a></li>
-  <li><a class="top" href="{% url 'top_feed_month' %}">{{top_name}}</a>
+  <li><a class="top">{{top_name}}</a>
     <ul class=collapsible>
         <li><a class="top-week" href="{% url 'top_feed_week' %}">week</a></li>
         <li><a class="top-month" href="{% url 'top_feed_month' %}">month</a></li>


### PR DESCRIPTION
Found a bug in the new top dropdown menu. The top of the menu is a clickable link that always goes to top/month. (And it makes the menu hard to use on mobile). Removed.

Also added some lint fixes of the css file from previous PR. Note to self: Make Travis fail if the css beautifier has to change something.

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving. (no issue)
