### PR TITLE
Fix white-on-white in dark themed top-sort-list

### DIFF
--- a/dwitter/static/theme_dark.css
+++ b/dwitter/static/theme_dark.css
@@ -61,6 +61,10 @@ ul.messages li {
   color: white;
 }
 
+.top-sort-list a {
+  background: #4b4b4b;
+}
+
 .like-button {
   border: 1px solid black;
 }


### PR DESCRIPTION
In Firefox 64.0 with the dark theme, the menu for the top dweet's period is rendered in white-on-white. A single CSS rule sets the background appropriately (to match the header).