### PR TITLE
Use absolute favicon paths

### DIFF
--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="description" content="{% block meta_description %}{% endblock %}">
     <title>{% block title %} Dwitter {% endblock %}</title>
-    <link rel="shortcut icon" href="static/favicon.ico" type="image/x-icon">
-    <link rel="icon" href="static/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="/static/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/static/favicon.ico" type="image/x-icon">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% load compress %}
 


### PR DESCRIPTION
Should fix missing favicons on some pages (like https://www.dwitter.net/u/lionleaf).

I didn't test it or anything...