### PR TITLE
Char count fix

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -322,7 +322,7 @@ def dweet(request):
 
     code = request.POST['code']
 
-    if(len(code.replace('\r\n', '\n')) > 140):
+    if(Dweet.length_of_code(code) > 140):
         return HttpResponseBadRequest("Dweet code too long! Code: " + code)
 
     d = Dweet(code=code,
@@ -353,7 +353,7 @@ def dweet_reply(request, dweet_id):
 
     code = request.POST['code']
 
-    if(len(code.replace('\r\n', '\n')) > 140):
+    if(Dweet.length_of_code(code) > 140):
         return HttpResponseBadRequest("Dweet code too long! Code: " + code)
 
     reply_to = get_object_or_404(Dweet, id=dweet_id)

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -60,6 +60,17 @@ class Dweet(models.Model):
         """
         return self.comments.first()
 
+    @staticmethod
+    def length_of_code(code):
+        """
+        Centralize the character counting to one place
+        """
+        return len(code.replace('\r\n', '\n'))
+
+    @cached_property
+    def dweet_length(self):
+        return Dweet.length_of_code(self.code)
+
     @cached_property
     def has_sticky_comment(self):
         """

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -92,7 +92,7 @@
               {{ dweet.posted | date:"M j Y g:i A" }} UTC
             </time>
           </p>
-          <code class="function-wrap">}// <div class=character-count>{{ dweet.code | length }}/140</div>
+          <code class="function-wrap">}// <div class=character-count>{{ dweet.dweet_length }}/140</div>
           </code>
       </br>
       <div class=error-display></div>


### PR DESCRIPTION
Fixes #462 

Katkip and KilledByAPixel was right on discord, it was an issue of double newline characters. This code change adds a single code path for character length calculation in python which should hopefully avoid different math in different locations in the future.

Oops, forgot to rebase before first push, so this PR shows all the commits from #461 as well :| 