### PR TITLE
Make remixing slightly more user-friendly

### DIFF
--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -144,17 +144,35 @@ function registerOnKeyListener(dweet) {
   var iframe = $(dweet).find('.dweetiframe')[0];
   var editor = $(dweet).find('.code-input')[0];
   var changedDweetMenu = $(dweet).find('.dweet-changed');
+  var submitButton = $(dweet).find('.remix-button,.dweet-button')[0];
+  var captionField = $(dweet).find('.new-dweet-comment-input')[0];
+  var captionFieldDisabled = 'Change the code...';
+
+  // Use the string from the template:
+  var captionFieldEnabled = $(captionField).prop('placeholder');
+
   var oldCode = editor.value;
   var originalCode = oldCode;
 
   showCode(iframe, oldCode);
+
+  editor.addEventListener('focus', function() {
+    changedDweetMenu.show();
+    $(submitButton).prop('disabled', true);
+    $(captionField).prop('placeholder', captionFieldDisabled);
+  });
+
   editor.addEventListener('keyup', function() {
     showStats(dweet, iframe);
 
+    changedDweetMenu.show();
+
     if (editor.value === originalCode) {
-      changedDweetMenu.hide();
+      $(submitButton).prop('disabled', true);
+      $(captionField).prop('placeholder', captionFieldDisabled);
     } else {
-      changedDweetMenu.show();
+      $(submitButton).prop('disabled', false);
+      $(captionField).prop('placeholder', captionFieldEnabled);
     }
 
     if (editor.value === oldCode) {

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -109,7 +109,7 @@
             {% if not embed %}
             {% if request.user.is_authenticated %}
             <div class=post-dweet-div>
-                <input type=text placeholder="Add a caption..." name="first-comment" class="new-dweet-comment-input" />
+                <input type=text placeholder="Add a caption here..." name="first-comment" class="new-dweet-comment-input" />
                 <input
                     class="remix-button"
                     type="submit"

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -37,7 +37,7 @@ x.fillRect(400+i*100+S(t)*300,400,50,200) // draw 50x200 rects</textarea>
       <div class=dweet-changed>
       {% if request.user.is_authenticated %}
         <div class=post-dweet-div>
-        <input type=text placeholder="Add a caption..." name="first-comment" class="new-dweet-comment-input" />
+        <input type=text placeholder="Add a caption here..." name="first-comment" class="new-dweet-comment-input" />
         <input
           class=dweet-button
           type="submit"


### PR DESCRIPTION
By showing the remix button on focus rather than on code change it
should be easier to find.

Current behavior:
The button to post a remix only shows up when you have changed the
dweet.

New behavior:
When a user clicks the code (ie. focus change) the remix button shows
up, but it starts out disabled.
The field you enter a comment in tells the user that he should edit the
code.
Once the code has changed, the remix button is enabled and the
text in the comment field changes to "Add a caption here..."

<img width="622" alt="Screen Shot 2020-02-08 at 6 09 03 PM" src="https://user-images.githubusercontent.com/610925/74094952-520b9380-4a9e-11ea-8157-7a6d29563b0a.png">
<img width="631" alt="Screen Shot 2020-02-08 at 6 08 30 PM" src="https://user-images.githubusercontent.com/610925/74094953-546ded80-4a9e-11ea-9305-c6f4cdeaef69.png">
<img width="655" alt="Screen Shot 2020-02-08 at 6 08 41 PM" src="https://user-images.githubusercontent.com/610925/74094955-5768de00-4a9e-11ea-963a-cdd9bb6e29fe.png">

