### PR TITLE
Add automatic dark mode

### DIFF
--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -54,30 +54,31 @@
           theme = matchMedia('(prefers-color-scheme: dark)').matches ? themes[1] : themes[0];
         }
 
-        // Check for compatibility
-        if (window.localStorage) {
-          window.switchTheme = function() {
-            // Shift themes
-            theme = themes[(themes.indexOf(theme) + 1) % themes.length];
-            localStorage.setItem('theme', theme);
-            location.reload();
-            // Call this function in the li to change the mode
-          };
-        }
-
-        if (themeUrls[theme]) {
-          var l = document.createElement('link');
-          l.setAttribute('href', themeUrls[theme]);
-          l.setAttribute('type', 'text/css');
-          l.setAttribute('rel', 'stylesheet');
-          l.setAttribute('id', 'theme-style');
-          document.head.appendChild(l);
-        } else {
+        function updateTheme() {
           var l = document.getElementById('theme-style');
           if (l) {
             l.parentNode.removeChild(l);
           }
+          if (themeUrls[theme]) {
+            var l = document.createElement('link');
+            l.setAttribute('href', themeUrls[theme]);
+            l.setAttribute('type', 'text/css');
+            l.setAttribute('rel', 'stylesheet');
+            l.setAttribute('id', 'theme-style');
+            document.head.appendChild(l);
+          }
         }
+
+        updateTheme();
+
+        window.switchTheme = function() {
+          // Shift themes
+          theme = themes[(themes.indexOf(theme) + 1) % themes.length];
+          window.localStorage && localStorage.setItem('theme', theme);
+          updateTheme();
+
+          // Call this function in the li to change the mode
+        };
       })();
     </script>
     <div class="head-menu clear-fix">

--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -36,43 +36,41 @@
   </head>
   <body class="{% block body_class %}{% endblock %}">
     <script type="text/javascript">
-      // Check for compatibility
-      if (window.localStorage) {
-        var switchTheme = function() {
-          // Shift themes
-          var theme = localStorage.getItem('theme');
-          if (!theme) {
-            localStorage.setItem('theme', 'dark');
-          } else if (theme === 'dark') {
-            localStorage.setItem('theme', 'green');
-          } else if (theme === 'green') {
-            localStorage.setItem('theme', 'hcontrast');
-          } else {
-            localStorage.setItem('theme', '');
-          }
-          location.reload();
-          // Call this function in the li to change the mode
+      (function() {
+        var themes = ['', 'dark', 'green', 'hcontrast'];
+        var themeUrls = {
+          dark: '{% static "theme_dark.css" %}',
+          green: '{% static "theme_green.css" %}',
+          hcontrast: '{% static "theme_hcontrast.css" %}'
         };
+        // Check for compatibility
+        if (window.localStorage) {
+          window.switchTheme = function() {
+            // Shift themes
+            var theme = localStorage.getItem('theme') || themes[0];
+            var nextTheme = themes[(themes.indexOf(theme) + 1) % themes.length];
+            localStorage.setItem('theme', nextTheme);
+            location.reload();
+            // Call this function in the li to change the mode
+          };
 
-        // Do the same thing outside the function without changing localStorage to set correct theme
-        var theme = localStorage.getItem('theme');
-        if (theme) {
-          var l = document.createElement('link');
-          if (theme === 'hcontrast') l.setAttribute('href', '{% static "theme_hcontrast.css" %}');
-          if (theme === 'green') l.setAttribute('href', '{% static "theme_green.css" %}');
-          if (theme === 'dark') l.setAttribute('href', '{% static "theme_dark.css" %}');
-          // if(theme==='blue') l.setAttribute('href', '{% static "theme_blue.css" %}');
-          l.setAttribute('type', 'text/css');
-          l.setAttribute('rel', 'stylesheet');
-          l.setAttribute('id', 'theme-style');
-          document.head.appendChild(l);
-        } else {
-          var l = document.getElementById('theme-style');
-          if (l) {
-            l.parentNode.removeChild(l);
+          // Do the same thing outside the function without changing localStorage to set correct theme
+          var theme = localStorage.getItem('theme');
+          if (themeUrls[theme]) {
+            var l = document.createElement('link');
+            l.setAttribute('href', themeUrls[theme]);
+            l.setAttribute('type', 'text/css');
+            l.setAttribute('rel', 'stylesheet');
+            l.setAttribute('id', 'theme-style');
+            document.head.appendChild(l);
+          } else {
+            var l = document.getElementById('theme-style');
+            if (l) {
+                l.parentNode.removeChild(l);
+            }
           }
         }
-      }
+      })();
     </script>
     <div class="head-menu clear-fix">
       <div class=head-menu-inner>

--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -37,7 +37,7 @@
   <body class="{% block body_class %}{% endblock %}">
     <script type="text/javascript">
       (function() {
-        var themes = ['', 'dark', 'green', 'hcontrast'];
+        var themes = ['light', 'dark', 'green', 'hcontrast'];
         var themeUrls = {
           dark: '{% static "theme_dark.css" %}',
           green: '{% static "theme_green.css" %}',

--- a/dwitter/templates/base.html
+++ b/dwitter/templates/base.html
@@ -43,31 +43,39 @@
           green: '{% static "theme_green.css" %}',
           hcontrast: '{% static "theme_hcontrast.css" %}'
         };
+        // Use saved theme if localStorage is available
+        var theme = window.localStorage ? localStorage.getItem('theme') : null;
+        // Ignore unknown theme
+        if (themes.indexOf(theme) == -1) {
+          theme = null;
+        }
+        // Use dark mode preference if no theme is set
+        if (typeof theme != 'string' && window.matchMedia) {
+          theme = matchMedia('(prefers-color-scheme: dark)').matches ? themes[1] : themes[0];
+        }
+
         // Check for compatibility
         if (window.localStorage) {
           window.switchTheme = function() {
             // Shift themes
-            var theme = localStorage.getItem('theme') || themes[0];
-            var nextTheme = themes[(themes.indexOf(theme) + 1) % themes.length];
-            localStorage.setItem('theme', nextTheme);
+            theme = themes[(themes.indexOf(theme) + 1) % themes.length];
+            localStorage.setItem('theme', theme);
             location.reload();
             // Call this function in the li to change the mode
           };
+        }
 
-          // Do the same thing outside the function without changing localStorage to set correct theme
-          var theme = localStorage.getItem('theme');
-          if (themeUrls[theme]) {
-            var l = document.createElement('link');
-            l.setAttribute('href', themeUrls[theme]);
-            l.setAttribute('type', 'text/css');
-            l.setAttribute('rel', 'stylesheet');
-            l.setAttribute('id', 'theme-style');
-            document.head.appendChild(l);
-          } else {
-            var l = document.getElementById('theme-style');
-            if (l) {
-                l.parentNode.removeChild(l);
-            }
+        if (themeUrls[theme]) {
+          var l = document.createElement('link');
+          l.setAttribute('href', themeUrls[theme]);
+          l.setAttribute('type', 'text/css');
+          l.setAttribute('rel', 'stylesheet');
+          l.setAttribute('id', 'theme-style');
+          document.head.appendChild(l);
+        } else {
+          var l = document.getElementById('theme-style');
+          if (l) {
+            l.parentNode.removeChild(l);
           }
         }
       })();


### PR DESCRIPTION
Use _dark_ theme if no theme preference is set and dark mode is preferred (via [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)).

Features:
* Dark mode is used if it’s set in the OS.
* Preference from local storage overrides dark mode.
* "Next theme" button is aware of dark mode preference and will avoid switching to same theme.
* Theme handling code deals with adding and removing themes gracefully.
* Wrap everything in IIFE to avoid spamming global name space.

PS: I ran the linter but all I got were errors in files I didn’t touch.