### PR TITLE
Remove extra num_comments annotation

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -54,10 +54,6 @@ class DweetFeed(ListView):
     def get_queryset(self):
         queryset = self.get_dweet_list()
         queryset = queryset.annotate(num_likes=Count('likes'))
-        queryset = queryset.extra(select={
-            'num_comments':
-            'SELECT COUNT(*) from dwitter_comment where reply_to_id = dwitter_dweet.id',
-        })
         queryset = queryset.order_by(*self.get_ordering())
 
         # Optimize the SQL query:

--- a/dwitter/templates/feed.html
+++ b/dwitter/templates/feed.html
@@ -94,12 +94,16 @@ Dwitter is a social network for building and sharing visual javascript demos lim
 
   {% if request.user.is_authenticated %}
     {% for dweet in dweets %}
-      {% include 'snippets/dweet_card.html' %}
+      {% with comments=dweet.comments.all %}
+        {% include 'snippets/dweet_card.html' %}
+      {% endwith %}
     {% endfor %}
   {% else %}
     {% for dweet in dweets %}
       {% cache 60 dweetcard dweet.pk %}
-      {% include 'snippets/dweet_card.html' %}
+      {% with comments=dweet.comments.all %}
+        {% include 'snippets/dweet_card.html' %}
+      {% endwith %}
       {% endcache %}
     {% endfor %}
   {% endif %}

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -142,16 +142,16 @@
     </ul>
     {% endif %}
     <ul class=comments>
-      {%if dweet.num_comments > 6 %}
+      {%if comments|length > 6 %}
           <li>
             <a href="#" class="show-more-comments">
               Show more comments…
             </a>
           </li>
       {% endif %}
-      {% for comment in dweet.comments.all|dictsortreversed:"posted" reversed %}
+      {% for comment in comments|dictsortreversed:"posted" reversed %}
       {% if comment != dweet.top_comment or not dweet.has_sticky_comment %}
-      <li class="comment {% if dweet.num_comments > 6 and dweet.num_comments|add:"-4" > forloop.counter0 %} hidden {% endif %}">
+      <li class="comment {% if comments|length > 6 and comments|length|add:"-4" > forloop.counter0 %} hidden {% endif %}">
       <a class=comment-name href="{% url 'user_feed' url_username=comment.author.username %}">
           <div class="avatar" style="background-image: url({{ comment.author.email | to_gravatar_url }})"></div>
           <div><span class="faded">u/</span>{{ comment.author.username }}</div>


### PR DESCRIPTION
We already prefetch all the comments, since all comments are always
rendered (even when a 'load more' button is shown). Therefore, we don't
need to also annotate the num_comments on the queryset. I am unsure how
much impact this annotation has on performance in production, since I
probably don't have a similar enough setup when running locally, but
I've confirmed that this refactor at least does not _add_ any SQL
queries (the count is 5 with and without this change - 7 when logged in).

According to statistics in New Relic, almost all the time in the
HotDweetFeed (the frontpage) is spent executing 3 SQL queries touching
the dwitter_comment table. That would be:
1) a COUNT query to check how many objects there are in total (for
pagination) - this is done automatically by django - maybe we can
optimize this away
2) The main select getting the list of dweets as well as annotations
3) a prefetch to actually load all related comments

With the free version of New Relic, I can't dig deeper into each of the
variants or what part of the queries are slow. But I know that all
annotations added to the queryset for use as part of (2) also get
executed in (1).
And this num_comments annotation at least seems safe to start by
removing to see what impact it has before investigating which other
things may be optimized.

When opening your Pull Request, we encourage you to do the following (you can add an X to check each task):

- [ ] Run `make lint` to ensure that all the files are formatted and using best practices.
- [ ] Link to any issues this PR is solving.
