### PR TITLE
Split our dweet reply info to separate query

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -66,8 +66,7 @@ class DweetFeed(ListView):
         queryset = (
             queryset
             .select_related('author')
-            .select_related('reply_to')
-            .select_related('reply_to__author')
+            .prefetch_related(Prefetch('reply_to', queryset=Dweet.objects.select_related('author')))
             .prefetch_related('likes')
             .prefetch_related(prefetch_comments)
             .prefetch_related(prefetch_replies))


### PR DESCRIPTION
Rather than joining on the dweet and user table one extra time in the
main query (which needs to be sorted and is already quite huge), this
splits out the query for loading information about the dweet to a
separate query. That means the total number of SQL queries on the
frontpage will increase by one, but I believe the total execution time
and amount of data to load from the database will be smaller, since the
data is joined in python instead.
