### PR TITLE
Improve foreign key rendering in django-admins

### DIFF
--- a/dwitter/admin.py
+++ b/dwitter/admin.py
@@ -3,5 +3,13 @@ from .models import Comment
 from .models import Dweet
 
 
-admin.site.register(Dweet)
-admin.site.register(Comment)
+class DweetAdmin(admin.ModelAdmin):
+    raw_id_fields = ('author', 'reply_to', 'likes',)
+
+
+class CommentAdmin(admin.ModelAdmin):
+    raw_id_fields = ('author', 'reply_to',)
+
+
+admin.site.register(Dweet, DweetAdmin)
+admin.site.register(Comment, CommentAdmin)


### PR DESCRIPTION
This makes django-admin views load faster (i.e. not time out) by
avoiding rendering of 17k row html select widgets.

When opening your Pull Request, we encourage you to do the following (you can add an X to check each task):

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.
