### PR TITLE
Autoplay first dweet in the feed

### DIFF
--- a/dwitter/static/js/scrolling.js
+++ b/dwitter/static/js/scrolling.js
@@ -154,7 +154,6 @@ function registerOnKeyListener(dweet) {
   var oldCode = editor.value;
   var originalCode = oldCode;
 
-  showCode(iframe, oldCode);
 
   editor.addEventListener('focus', function() {
     changedDweetMenu.show();

--- a/dwitter/templates/feed.html
+++ b/dwitter/templates/feed.html
@@ -94,14 +94,14 @@ Dwitter is a social network for building and sharing visual javascript demos lim
 
   {% if request.user.is_authenticated %}
     {% for dweet in dweets %}
-      {% with comments=dweet.comments.all %}
+      {% with comments=dweet.comments.all autoplay=forloop.first %}
         {% include 'snippets/dweet_card.html' %}
       {% endwith %}
     {% endfor %}
   {% else %}
     {% for dweet in dweets %}
       {% cache 60 dweetcard dweet.pk %}
-      {% with comments=dweet.comments.all %}
+      {% with comments=dweet.comments.all autoplay=forloop.first %}
         {% include 'snippets/dweet_card.html' %}
       {% endwith %}
       {% endcache %}

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -6,7 +6,7 @@
     <div class=canvas-iframe-container-wrapper>
       <div class=canvas-iframe-container >
         <iframe class="dweetiframe"
-          src="{% url 'fullscreen_dweet' dweet_id=dweet.id host 'dweet' %}"
+                src="{% url 'fullscreen_dweet' dweet_id=dweet.id host 'dweet' %}?{% if autoplay %}autoplay=1{% endif %}"
           sandbox="allow-same-origin allow-scripts" id="{{ dweet.id }}"></iframe>
       </div>
     </div>


### PR DESCRIPTION
Also removes the call to newCode on load. While this is required to instrument the code, it already happens within `templates/dweet.html` so we were doing it twice.

This causes the first dweet to show up quicker, but since it starts before the page is fully loaded you might get some extra stutter.

I'd like feedback on whether that's worth it? Earlier dweet but extra stutter.