### PR TITLE
Only annotate num_likes on Top views

### DIFF
--- a/dwitter/tests/feed/test_feed_views.py
+++ b/dwitter/tests/feed/test_feed_views.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from datetime import timedelta
 
 
-class DweetFeedTestCase():  # Not inheriting from TestCase, an abstract test class if you will
+class DweetFeedMixin:  # Not inheriting from TestCase, an abstract test class if you will
     request_factory = RequestFactory()
 
     def setUp(self):
@@ -90,15 +90,6 @@ class DweetFeedTestCase():  # Not inheriting from TestCase, an abstract test cla
                                reply_to=self.hottest_dweet,
                                author=users[2])
 
-    def test_annotation(self):
-        queryset = self.dweetFeed.get_queryset()
-        for dweet in queryset:
-            try:
-                num_likes = dweet.num_likes
-                self.assertTrue(num_likes >= 0)
-            except:
-                self.fail("queryset missing num_likes annotation")
-
     def test_queryset_count(self):
         queryset = self.dweetFeed.get_queryset()
         self.assertEqual(queryset.count(), self.nr_dweets)
@@ -116,7 +107,18 @@ class DweetFeedTestCase():  # Not inheriting from TestCase, an abstract test cla
         self.assertIn('<title>' + self.dweetFeed.title + '</title>', html)
 
 
-class HotDweetFeedTests(DweetFeedTestCase, TestCase):
+class TopFeedTestMixin:
+    def test_annotation(self):
+        queryset = self.dweetFeed.get_queryset()
+        for dweet in queryset:
+            try:
+                num_likes = dweet.num_likes
+                self.assertTrue(num_likes >= 0)
+            except:
+                self.fail("queryset missing num_likes annotation")
+
+
+class HotDweetFeedTests(DweetFeedMixin, TestCase):
     dweetFeed = HotDweetFeed()
 
     def test_hot_sort(self):
@@ -129,7 +131,7 @@ class HotDweetFeedTests(DweetFeedTestCase, TestCase):
             prev_hotness = dweet.hotness
 
 
-class TopWeekDweetFeedTests(DweetFeedTestCase, TestCase):
+class TopWeekDweetFeedTests(DweetFeedMixin, TopFeedTestMixin, TestCase):
     dweetFeed = TopWeekDweetFeed()
 
     def test_top_sort(self):
@@ -149,7 +151,7 @@ class TopWeekDweetFeedTests(DweetFeedTestCase, TestCase):
         self.assertEqual(queryset.count(), self.nr_dweets - 3)
 
 
-class TopMonthDweetFeedTests(DweetFeedTestCase, TestCase):
+class TopMonthDweetFeedTests(DweetFeedMixin, TopFeedTestMixin, TestCase):
     dweetFeed = TopMonthDweetFeed()
 
     def test_top_sort(self):
@@ -169,7 +171,7 @@ class TopMonthDweetFeedTests(DweetFeedTestCase, TestCase):
         self.assertEqual(queryset.count(), self.nr_dweets - 2)
 
 
-class TopYearDweetFeedTests(DweetFeedTestCase, TestCase):
+class TopYearDweetFeedTests(DweetFeedMixin, TopFeedTestMixin, TestCase):
     dweetFeed = TopYearDweetFeed()
 
     def test_top_sort(self):
@@ -189,7 +191,7 @@ class TopYearDweetFeedTests(DweetFeedTestCase, TestCase):
         self.assertEqual(queryset.count(), self.nr_dweets - 1)
 
 
-class TopAllDweetFeedTests(DweetFeedTestCase, TestCase):
+class TopAllDweetFeedTests(DweetFeedMixin, TopFeedTestMixin, TestCase):
     dweetFeed = TopAllDweetFeed()
 
     def test_top_sort(self):
@@ -204,7 +206,7 @@ class TopAllDweetFeedTests(DweetFeedTestCase, TestCase):
             prev_score = dweet.num_likes
 
 
-class NewDweetFeedTests(DweetFeedTestCase, TestCase):
+class NewDweetFeedTests(DweetFeedMixin, TestCase):
     dweetFeed = NewDweetFeed()
 
     def test_new_sort(self):
@@ -216,5 +218,5 @@ class NewDweetFeedTests(DweetFeedTestCase, TestCase):
             prev_date = dweet.posted
 
 
-class RandomDweetFeedTests(DweetFeedTestCase, TestCase):
+class RandomDweetFeedTests(DweetFeedMixin, TestCase):
     dweetFeed = RandomDweetFeed()

--- a/dwitter/tests/feed/test_hashtag_feed_views.py
+++ b/dwitter/tests/feed/test_hashtag_feed_views.py
@@ -45,16 +45,6 @@ class HashtagFeedTestCase():  # Not inheriting from TestCase, an abstract test c
                                reply_to=dweets[3],
                                author=users[2])
 
-    def test_annotation(self):
-        self.dweetFeed.kwargs = {'hashtag_name': 'everyone'}
-        queryset = self.dweetFeed.get_queryset()
-        for dweet in queryset:
-            try:
-                num_likes = dweet.num_likes
-                self.assertTrue(num_likes >= 0)
-            except:
-                self.fail("queryset missing num_likes annotation")
-
     def test_404_empty_hashtag(self):
         request = self.request_factory.get('/')
         request.session = {}
@@ -79,6 +69,7 @@ class HashtagFeedTestCase():  # Not inheriting from TestCase, an abstract test c
         self.assertNotIn('<title>' + self.dweetFeed.title + '</title>', html)
 
     def test_got_title(self):
+        self.dweetFeed.kwargs = {'hashtag_name': 'everyone'}
         request = self.request_factory.get('/')
         request.session = {}
         response = self.dweetFeed.__class__.as_view()(request, hashtag_name='everyone')
@@ -106,6 +97,16 @@ class TopHashtagFeedTests(HashtagFeedTestCase, TestCase):
         for dweet in queryset:
             self.assertTrue(prev_score >= dweet.num_likes, "Should sort by num likes")
             prev_score = dweet.num_likes
+
+    def test_annotation(self):
+        self.dweetFeed.kwargs = {'hashtag_name': 'everyone'}
+        queryset = self.dweetFeed.get_queryset()
+        for dweet in queryset:
+            try:
+                num_likes = dweet.num_likes
+                self.assertTrue(num_likes >= 0)
+            except:
+                self.fail("queryset missing num_likes annotation")
 
 
 class NewHashtagFeedTests(HashtagFeedTestCase, TestCase):

--- a/dwitter/tests/feed/test_user_feeds.py
+++ b/dwitter/tests/feed/test_user_feeds.py
@@ -49,6 +49,14 @@ class UserFeedTestCase():  # Not inheriting from TestCase, an abstract test clas
         # Each user have 10 dweets from setUp
         self.assertEqual(queryset.count(), 10)
 
+
+class NewUserFeedTests(UserFeedTestCase, TestCase):
+    dweetFeed = NewUserFeed()
+
+
+class TopUserFeedTests(UserFeedTestCase, TestCase):
+    dweetFeed = TopUserFeed()
+
     def test_annotation(self):
         self.dweetFeed.kwargs = {'url_username': self.users[1].username}
         queryset = self.dweetFeed.get_queryset()
@@ -58,14 +66,6 @@ class UserFeedTestCase():  # Not inheriting from TestCase, an abstract test clas
                 self.assertEqual(num_likes, dweet.likes.count())
             except:
                 self.fail("queryset missing num_likes annotation")
-
-
-class NewUserFeedTests(UserFeedTestCase, TestCase):
-    dweetFeed = NewUserFeed()
-
-
-class TopUserFeedTests(UserFeedTestCase, TestCase):
-    dweetFeed = TopUserFeed()
 
 
 class HotUserFeedTests(UserFeedTestCase, TestCase):


### PR DESCRIPTION
The num_likes annotation is quite heavy, so avoiding it on pages where
it is not used seems smart.

With this, only the TopAllDweetFeed view should be particularly slow,
hopefully (the rest of the top views are fast since they start by
filtering out a lot of data based on posted at date before doing their
sorting).

When opening your Pull Request, we encourage you to do the following (you can add an X to check each task):

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.
