### PR TITLE
Add prompt before overwritting setup from Makefile and stop css-fix from default lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
       - "3.6"
 sudo: false
 install:
-      - make setup
+      - yes | make setup
       - make update
       - nvm install 12.13
       - nvm use 12.13

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ migrations:
 	python manage.py makemigrations
 
 .PHONY: lint
-lint: lint-python lint-js-fix lint-css-fix
+lint: lint-python lint-js-fix
 
 .PHONY: lint-python
 lint-python:

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,12 @@ lint-css-fix:
 test:
 	python manage.py test
 
+.PHONY: check_setup
+check_setup:
+	@echo -n "Are you sure? This will overwrite your local.py settings file [y/N] " && read ans && [ $${ans:-N} = y ]
+
 .PHONY: setup
-setup:
+setup: check_setup
 	virtualenv venv
 	cp dwitter/settings/local.py.example dwitter/settings/local.py
 


### PR DESCRIPTION
...

I just think protection is a good idea, OK?!

Also, since we encourage everyone to run `make lint` before submitting a pull request, it's not ideal that it unpacks the whole font awesome one-liner every time :P Easy fix is to stop the css-fix

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.
