### PR TITLE
[apiv2] Update create dweet apiv2

### DIFF
--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -7,6 +7,7 @@ from django.http import HttpResponseBadRequest
 from django.urls import reverse
 from django.db.models import Count, Sum, Prefetch
 from ..models import Dweet, Hashtag, Comment
+from dwitter.utils import length_of_code
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.utils import timezone
@@ -330,7 +331,7 @@ def dweet(request):
 
     code = request.POST['code']
 
-    if(Dweet.length_of_code(code) > 140):
+    if(length_of_code(code) > 140):
         return HttpResponseBadRequest("Dweet code too long! Code: " + code)
 
     d = Dweet(code=code,
@@ -361,7 +362,7 @@ def dweet_reply(request, dweet_id):
 
     code = request.POST['code']
 
-    if(Dweet.length_of_code(code) > 140):
+    if(length_of_code(code) > 140):
         return HttpResponseBadRequest("Dweet code too long! Code: " + code)
 
     reply_to = get_object_or_404(Dweet, id=dweet_id)

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -8,6 +8,8 @@ from django.db.models.signals import pre_delete, post_save, m2m_changed
 from math import log
 from datetime import datetime
 
+from .utils import length_of_code
+
 
 def get_sentinel_user():
     users = get_user_model().objects
@@ -60,16 +62,9 @@ class Dweet(models.Model):
         """
         return self.comments.first()
 
-    @staticmethod
-    def length_of_code(code):
-        """
-        Centralize the character counting to one place
-        """
-        return len(code.replace('\r\n', '\n'))
-
     @cached_property
     def dweet_length(self):
-        return Dweet.length_of_code(self.code)
+        return length_of_code(self.code)
 
     @cached_property
     def has_sticky_comment(self):

--- a/dwitter/utils.py
+++ b/dwitter/utils.py
@@ -1,0 +1,6 @@
+
+def length_of_code(code):
+    """
+    Centralize the character counting to one place
+    """
+    return len(code.replace('\r\n', '\n'))


### PR DESCRIPTION
No longer mocks a request to the old view.
Adds support for "remix_of" in the dweet creation api.

Refactoring to using the Serializer and a Validator is out of scope for this change. Should possibly be considered later.

This enables https://github.com/dwitter-net/dwitter-frontend/pull/49 

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.
