### PR TITLE
Makes it possible to log in with usernames over 30 characters

### DIFF
--- a/dwitter/templates/registration/login.html
+++ b/dwitter/templates/registration/login.html
@@ -12,7 +12,7 @@
     </label>
     <input
         id="id_username"
-        maxlength="30"
+        maxlength="150"
         name="username"
         type="text"
         placeholder="..."


### PR DESCRIPTION
The maximum supported length of usernames in the database is 150 characters, however, the login screen does not currently support usernames over 30 characters. This makes it hard to test with longer usernames.

The registration form also caps the username that someone can enter to 30 characters, but this is only checked client side, so it is not impossible to get registered users with names that can't login by default.