### PR TITLE
fix: treat hashtags with a preceding : as anchors (fixes #474)

### DIFF
--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -141,7 +141,7 @@ class Hashtag(models.Model):
 # Should be idempotent.
 @receiver(post_save, sender=Comment, dispatch_uid="add_hashtags_from_comment")
 def add_hashtags(sender, instance, **kwargs):
-    hash_pattern = re.compile(r'#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)')
+    hash_pattern = re.compile(r'(?:^|\s)(?=\S*#)(?!\S*:)\S*#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)')
     for hashtag in re.findall(hash_pattern, instance.text):
         h = Hashtag.objects.get_or_create(name=hashtag.lower())[0]
         if not h.dweets.filter(id=instance.reply_to.id).exists():

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -141,6 +141,12 @@ class Hashtag(models.Model):
 # Should be idempotent.
 @receiver(post_save, sender=Comment, dispatch_uid="add_hashtags_from_comment")
 def add_hashtags(sender, instance, **kwargs):
+    # (?:^|\s)    # go to the start of the line or the next space
+    # (?=\S*#)    # lookahead to see is there a '#' after a bunch of non-whitespace characters?
+    # (?!\S*:)    # lookahead to check aren't any ':' characters there (otherwise it's likely an anchor)
+    # \S*#        # skip any of the characters leading up to the '#'
+    # then do the hashtag grouping that was there before:
+    # (?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)        
     hash_pattern = re.compile(r'(?:^|\s)(?=\S*#)(?!\S*:)\S*#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)')
     for hashtag in re.findall(hash_pattern, instance.text):
         h = Hashtag.objects.get_or_create(name=hashtag.lower())[0]

--- a/dwitter/templatetags/insert_magic_links.py
+++ b/dwitter/templatetags/insert_magic_links.py
@@ -44,7 +44,8 @@ def insert_magic_links(text):
     )
     text = re.sub(
         r'(?P<text>'                                            # capture original pattern
-        r'#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)[^_a-zA-Z\d]?)',   # hashtag
+        # hashtag (that isn't preceded with a : so web anchors aren't considered)
+        r'(?:^|\s)(?=\S*#)(?!\S*:)\S*#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*))',
         hashtag_to_link,
         text
     )

--- a/dwitter/templatetags/insert_magic_links.py
+++ b/dwitter/templatetags/insert_magic_links.py
@@ -44,7 +44,12 @@ def insert_magic_links(text):
     )
     text = re.sub(
         r'(?P<text>'                                            # capture original pattern
-        # hashtag (that isn't preceded with a : so web anchors aren't considered)
+        # (?:^|\s)    # go to the start of the line or the next space
+        # (?=\S*#)    # lookahead to see is there a '#' after a bunch of non-whitespace characters?
+        # (?!\S*:)    # lookahead to check aren't any ':' characters there (otherwise it's likely an anchor)
+        # \S*#        # skip any of the characters leading up to the '#'
+        # then do the hashtag grouping that was there before:
+        # (?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)        
         r'(?:^|\s)(?=\S*#)(?!\S*:)\S*#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*))',
         hashtag_to_link,
         text

--- a/dwitter/tests/templatetags/test_insert_magic_links.py
+++ b/dwitter/tests/templatetags/test_insert_magic_links.py
@@ -192,9 +192,9 @@ class DweetTestCase(TestCase):
     def test_insert_magic_link_anchor_not_hashtag(self):
         self.assertEqual(
             '<a href="/h/start">#start</a> '
-            'https://www.site.com/page#anchor '
+            'https://www.example.com/page#anchor '
             '<a href="/h/end">#end</a>',
-            insert_magic_links('#start https://www.site.com/page#anchor #end')
+            insert_magic_links('#start https://www.example.com/page#anchor #end')
         )
 
     # mixed

--- a/dwitter/tests/templatetags/test_insert_magic_links.py
+++ b/dwitter/tests/templatetags/test_insert_magic_links.py
@@ -189,6 +189,14 @@ class DweetTestCase(TestCase):
             insert_magic_links('#1')
         )
 
+    def test_insert_magic_link_anchor_not_hashtag(self):
+        self.assertEqual(
+            '<a href="/h/start">#start</a> '
+            'https://www.site.com/page#anchor '
+            '<a href="/h/end">#end</a>',
+            insert_magic_links('#start https://www.site.com/page#anchor #end')
+        )
+
     # mixed
 
     def test_insert_magic_links_mixed(self):


### PR DESCRIPTION
This should fix #474, it was a little tricky as hashtags#likethis and /u/even#likethis are allowed so to explain the regex I came up with:

```
(?:^|\s)    # go to the start of the line or the next space
(?=\S*#)    # lookahead to see is there a '#' after a bunch of non-whitespace characters?
(?!\S*:)    # lookahead to check aren't any ':' characters there (otherwise it's likely an anchor)
\S*         # skip any of the characters leading up to the '#'
# then do the hashtag grouping that was there before:
#(?P<hashtag>[_a-zA-Z][_a-zA-Z\d]*)
```

I've created a little test for it which passes along with the rest.

First time running a Django project & first time contributing so if I've messed up anything let me know!

- [X] Run `make lint` to ensure that all the files are formatted and using best practices.
- [X] Link to any issues this PR is solving.
