### PR TITLE
Dweet Perf Fix - Compressor compatibility

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -134,11 +134,11 @@
       function newCode(code) {
           try {
             // uncompress
-            code = (code || '').replace(
+            let decode = (code || '').replace(
               /eval[(](unescape[(]escape`.+`[.]replace[(].+[)][)])[)]/,
               (m, u) => eval(u)
             );
-            userFunction = window.u = new Function("t", instrument(code));
+            userFunction = window.u = new Function("t", instrument(decode));
           } catch (e) {
             try {
               // try old way for compatibility


### PR DESCRIPTION
Compressor dweets e.g d/11852 rely on their compressed source string to
build their output. However The decompression perf improvement directly
mutates the "code" variable used by these compressors, breaking them.

This fix uses an independent local variable, preserving "code".
