### PR TITLE
User errors in code supplied by url parameter broke error msging

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -15,7 +15,7 @@
     </style>
     <script>
       var autoplay = getURLParameter('autoplay');
-      const src = getURLParameter('code');
+      const urlDweetSrc = getURLParameter('code');
       var lastError = "";
       var playing = !!autoplay;
       var FPS = 60;
@@ -230,7 +230,11 @@
     var frame = 0;
     var nextFrameMs = 0;
 
-    newCode(src);
+    try{
+      newCode(urlDweetSrc);
+    } catch (e) {
+      // Ignore errors, since urlDweetSrc can be malformed
+    }
 
     function loop(frame_time) {
       stats = stats || createStats();


### PR DESCRIPTION
This fix allows the errors to behave similar to the case where code is
supplied via messages.

The purpose of this is for the dweet not to crash, but rather send
iframe messages with the error which can then be displayed to the user

When opening your Pull Request, we encourage you to do the following (you can add an X to check each task):

Required to make https://github.com/dwitter-net/dwitter-frontend/pull/92 work

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.
