### PR TITLE
Optimize apiv2 dweet requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 dwitter/settings/local.py
 dwitter/static/CACHE/*
 dwitter/static/admin/*
+dwitter/static/silk/*
+dwitter/static/rest_framework/*
+dwitter/static/debug_toolbar/*
 *.db
 .gitignore
 .*.sw*

--- a/dwitter/feed/views.py
+++ b/dwitter/feed/views.py
@@ -58,14 +58,14 @@ class DweetFeed(ListView):
 
         # Optimize the SQL query:
         prefetch_comments = Prefetch('comments', queryset=Comment.objects.select_related('author'))
-        prefetch_replies = Prefetch('dweet_set', queryset=Dweet.objects.select_related('author'))
+        prefetch_remixes = Prefetch('remixes', queryset=Dweet.objects.select_related('author'))
         queryset = (
             queryset
             .select_related('author')
             .prefetch_related(Prefetch('reply_to', queryset=Dweet.objects.select_related('author')))
             .prefetch_related('likes')
             .prefetch_related(prefetch_comments)
-            .prefetch_related(prefetch_replies))
+            .prefetch_related(prefetch_remixes))
 
         return queryset
 

--- a/dwitter/models.py
+++ b/dwitter/models.py
@@ -32,7 +32,7 @@ class Dweet(models.Model):
     code = models.TextField()
     posted = models.DateTimeField(db_index=True)
     reply_to = models.ForeignKey("self", on_delete=models.DO_NOTHING,
-                                 null=True, blank=True)
+                                 related_name="remixes", null=True, blank=True)
 
     likes = models.ManyToManyField(User, related_name="liked", blank=True)
     hotness = models.FloatField(default=1.0, db_index=True)

--- a/dwitter/serializers_v2.py
+++ b/dwitter/serializers_v2.py
@@ -159,5 +159,3 @@ class DweetSerializer(serializers.ModelSerializer):
             'remixes',
             'has_user_awesomed',
         )
-
-

--- a/dwitter/serializers_v2.py
+++ b/dwitter/serializers_v2.py
@@ -122,22 +122,17 @@ class RemixOfSerializer(serializers.ModelSerializer):
         queryset=Dweet.with_deleted.all()
     )
 
-    awesome_count = serializers.SerializerMethodField()
     author = UserSerializer()
 
     class Meta:
         model = Dweet
         fields = (
             'author',
-            'awesome_count',
             'code',
             'id',
             'posted',
             'remix_of',
         )
-
-    def get_awesome_count(self, obj):
-        return obj.likes.all().count()
 
 
 class DweetSerializer(serializers.ModelSerializer):

--- a/dwitter/serializers_v2.py
+++ b/dwitter/serializers_v2.py
@@ -144,7 +144,7 @@ class DweetSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField(source='pk')
 
     remix_of = RemixOfSerializer(source='reply_to')
-    remixes = serializers.PrimaryKeyRelatedField(source='dweet_set', read_only=True, many=True)
+    remixes = serializers.PrimaryKeyRelatedField(read_only=True, many=True)
 
     awesome_count = serializers.SerializerMethodField()
     has_user_awesomed = serializers.SerializerMethodField()

--- a/dwitter/serializers_v2.py
+++ b/dwitter/serializers_v2.py
@@ -141,8 +141,8 @@ class DweetSerializer(serializers.ModelSerializer):
     remix_of = RemixOfSerializer(source='reply_to')
     remixes = serializers.PrimaryKeyRelatedField(read_only=True, many=True)
 
-    awesome_count = serializers.SerializerMethodField()
-    has_user_awesomed = serializers.SerializerMethodField()
+    awesome_count = serializers.IntegerField()
+    has_user_awesomed = serializers.BooleanField()
     author = UserSerializer()
     comments = CommentSerializer(many=True)
 
@@ -160,9 +160,4 @@ class DweetSerializer(serializers.ModelSerializer):
             'has_user_awesomed',
         )
 
-    def get_has_user_awesomed(self, dweet):
-        user = self.context['request'].user
-        return dweet.likes.filter(pk=user.pk).exists()
 
-    def get_awesome_count(self, obj):
-        return obj.likes.all().count()

--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -36,8 +36,8 @@
       <a class="dweet-option embed-dwitter-link"  href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank">full version</a>
       {% endif %}
       <a class="dweet-option" href="{% url 'dweet_show' dweet_id=dweet.id %}" target="_blank" data-popover=".share-container">share</a>
-      {% if dweet.dweet_set.count > 0 %}
-      <a class="dweet-option remixes-button" href="" data-popover=".remixes-container">{{ dweet.dweet_set.count }} remix{% if dweet.dweet_set.count > 1 %}es{% endif %}</a>
+      {% if dweet.remixes.count > 0 %}
+      <a class="dweet-option remixes-button" href="" data-popover=".remixes-container">{{ dweet.remixes.count }} remix{% if dweet.remixes.count > 1 %}es{% endif %}</a>
       {% endif %}
       {% if request.user == dweet.author or request.user.is_staff %}
         <form class="dweet-delete-form" action="{% url 'dweet_delete' dweet_id=dweet.id %}" method="post"
@@ -64,7 +64,7 @@
       </div>
       <div class="popover remixes-container">
         <ul>
-          {% for remix in dweet.dweet_set.all %}
+          {% for remix in dweet.remixes.all %}
             <li>
               <a href="{% url 'dweet_show' dweet_id=remix.id %}">
                 <span class="faded">d/</span>{{remix.id}}

--- a/dwitter/views_v2.py
+++ b/dwitter/views_v2.py
@@ -70,9 +70,9 @@ class DweetViewSet(mixins.RetrieveModelMixin,
                    viewsets.GenericViewSet):
     queryset = Dweet.objects.all().select_related(
         'author',
+        'reply_to',
+        'reply_to__author'
     ).prefetch_related(
-        Prefetch('reply_to', queryset=Dweet.objects.select_related('author')),
-        'likes',
         Prefetch('remixes'),
         Prefetch('comments', queryset=Comment.objects.select_related('author'))
     ).annotate(
@@ -139,9 +139,6 @@ class DweetViewSet(mixins.RetrieveModelMixin,
             filters['author__username'] = username
         if hashtag:
             filters['hashtag__name'] = hashtag
-
-        if order_by == '-awesome_count':
-            self.queryset = self.queryset.annotate(awesome_count=Count('likes'))
 
         self.queryset = self.queryset.annotate(
             has_user_awesomed=Exists(Dweet.objects.filter(


### PR DESCRIPTION
Reduces the number of DB queries performed for `GET apiv2beta/dweets` from ~44 to 8

This PR does the following:
 - Adds `related_name=remixes` to the `reply_to` field in the Dweet model. This was done to make it more intuitive to read code that uses the reverse relation. 
   - (Note: When writing this I realize there's an inconsistency between the terminology of dweet "replies" and "remixes" in the code. Maybe we should rename the `reply_to` field `remix_of` later to make it even clearer?)
 - Removes the awesome_count field from the remix-linked dweet. This was not used and generated an extra query for each dweet.
 - Changed awesome_count and has_user_awesomed from serializer methods to fields generated by annotation. Previously these two functions added 3 queries for each dweet.
 - `prefetch_related` for `remixes`, the original N+1 problem that led me down this path.
 - Added a `prefetch_related` for `reply_to` including prefetch of the related author user profile. Before I did that I saw a lot of extra user queries




When opening your Pull Request, we encourage you to do the following (you can add an X to check each task):

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.
