### PR TITLE
Add a quick shoutout to the new frontend

### DIFF
--- a/dwitter/templates/feed.html
+++ b/dwitter/templates/feed.html
@@ -88,8 +88,10 @@ Dwitter is a social network for building and sharing visual javascript demos lim
   {% if show_submit_box %}
   {% include 'snippets/new_dweet_card.html' %}
   {% endif %}
-
-    <div class="card">Current theme challenge: <a href="/h/scarymovies">#ScaryMovies</a>
+    <div class="card">
+    Try the new frontend: <a href="https://beta.dwitter.net">beta.dwitter.net</a>
+    <br />
+    Current theme challenge: <a href="/h/scarymovies">#ScaryMovies</a>
     </div>
 
   {% if request.user.is_authenticated %}


### PR DESCRIPTION
Hopefully, this will move some traffic to the new frontend, allowing us
to get some feedback as we're getting ready to switch frontend

Not the prettiest, but functional:

<img width="734" alt="Screen Shot 2021-10-29 at 4 16 55 PM" src="https://user-images.githubusercontent.com/610925/139496632-8166257a-8820-4a83-8322-d9e9d4d5cf04.png">


