### PR TITLE
Fix recording dweets on Chrome

### DIFF
--- a/dwitter/templates/snippets/dweet_card.html
+++ b/dwitter/templates/snippets/dweet_card.html
@@ -7,7 +7,7 @@
       <div class=canvas-iframe-container >
         <iframe class="dweetiframe"
                 src="{% url 'fullscreen_dweet' dweet_id=dweet.id host 'dweet' %}?code={{ dweet.code|urlencode }}"
-          sandbox="allow-same-origin allow-scripts" id="{{ dweet.id }}"></iframe>
+          sandbox="allow-same-origin allow-scripts allow-downloads" id="{{ dweet.id }}"></iframe>
       </div>
     </div>
     <div class=dweet-actions>

--- a/dwitter/templates/snippets/new_dweet_card.html
+++ b/dwitter/templates/snippets/new_dweet_card.html
@@ -7,7 +7,7 @@
       id="iframe-container-submit">
       <iframe class="dweetiframe" id=preview-iframe
       src="{% url 'blank_dweet' host 'dweet' %}"
-      sandbox="allow-scripts allow-same-origin"></iframe>
+      sandbox="allow-scripts allow-same-origin allow-downloads"></iframe>
     </div>
   </div>
   <div class="dweet-actions">


### PR DESCRIPTION
Currently when recording is done processing, you'll find this in the console: `Download is disallowed. The frame initiating or instantiating the download is sandboxed, but the flag ‘allow-downloads’ is not set. See https://www.chromestatus.com/feature/5706745674465280 for more details.`

---

- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.
