### PR TITLE
Quick fix for non-spoiler dweets to be played as before

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -22,6 +22,7 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
+        visibility: hidden;
       }
 
       #spoiler-text {
@@ -33,7 +34,8 @@
 
     </style>
     <script>
-      var spoiler = getURLParameter('spoiler');
+      var spoiler = !!getURLParameter('spoiler');
+
       var autoplay = spoiler ? null : getURLParameter('autoplay');
       const urlDweetSrc = getURLParameter('code');
       var lastError = "";
@@ -224,6 +226,10 @@
 
   <script>
 
+    if(spoiler){
+      var curtain = document.getElementById('curtain');
+      curtain.style.visibility = 'visible';
+    }
     function openSesame() {
       var curtain = document.getElementById('curtain');
       curtain.style.visibility = 'hidden';


### PR DESCRIPTION
This makes sure the dweets that are not tagged as spoiler will not have the curtain visible. 

Quick fix to #534 


- [x] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.
