### PR TITLE
Make document background white, in case the canvas is destroyed

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -17,6 +17,7 @@
       body {
         /* For the rare case when the dweet destroys the canvas, and the user has a non-white theme */
         background: white;
+        color: black;
       }
 
       #curtain {

--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -14,6 +14,11 @@
         background: white;
       }
 
+      body {
+        /* For the rare case when the dweet destroys the canvas, and the user has a non-white theme */
+        background: white;
+      }
+
       #curtain {
         width: 100%;
         height: 100%;


### PR DESCRIPTION
- [ ] Run `make lint` to ensure that all the files are formatted and using best practices.
- [x] Link to any issues this PR is solving.

Fixes: https://github.com/dwitter-net/dwitter-frontend/issues/136

Concerns:

- Was there ever a dweet that took advantage of the default transparency on the document background? I can't think of one...