### PR TITLE
Clarify time epsilon

### DIFF
--- a/dwitter/templates/dweet/dweet.html
+++ b/dwitter/templates/dweet/dweet.html
@@ -291,9 +291,8 @@
         nextFrameMs = Math.max(nextFrameMs + 1000 / FPS, frame_time);
       }
       time = frame/FPS;
-      if(time * FPS | 0 == frame - 1){
-        time += 0.000001;
-      }
+      // Add an epsilon otherwise t*60|0 sometimes evaluates to incorrect frame
+      time += frame && 0.000001;
       frame++;
 
       try {


### PR DESCRIPTION
`t*60|0` is often used in dweets to acquire the current frame, however `t/60` and `t*60` have asymmetric rounding error, and for some frames this causes `t*60|0` to evaluate to the previous frame.

The existing condition was intended to explicitly check for this mismatch and compensate by adding a small number to t. The condition is broken and actually adds 1e-6 to every non-zero frame, however this is not a problem until the 2147483648th frame, which is good enough.

We shouldn't fix the condition because some dweets are sensitive to t and will have come to depend on this detail. But we can re-write the code to reflect this choice, and comment it for preservation.